### PR TITLE
LandmarkAnnotationSet endpoint support

### DIFF
--- a/gcapi/gcapi.py
+++ b/gcapi/gcapi.py
@@ -14,7 +14,6 @@ from time import sleep, time
 from future.moves.urllib.parse import urljoin
 
 from requests import Session, post, ConnectionError
-from rfc3339_validator import validate_rfc3339
 
 
 def is_uuid(s):
@@ -37,32 +36,6 @@ def accept_tuples_as_arrays(org):
 Draft7ValidatorWithTupleSupport = jsonschema.validators.extend(
     jsonschema.Draft7Validator,
     type_checker=accept_tuples_as_arrays(jsonschema.Draft7Validator.TYPE_CHECKER),
-)
-
-
-def accept_datetime_string(org):
-    """
-    Adds support for validation of datetime strings in schemas by adding a new value
-    for the `type` key in schemas called `datetime`. Instances validated using this
-    type will be
-    Parameters
-    ----------
-    org
-
-    Returns
-    -------
-
-    """
-    return org.redefine(
-        "datetime",
-        lambda checker, instance: isinstance(instance, str)
-        and validate_rfc3339(instance),
-    )
-
-
-Draft7ValidatorWithTupleAndDateTimeSupport = jsonschema.validators.extend(
-    Draft7ValidatorWithTupleSupport,
-    type_checker=accept_datetime_string(Draft7ValidatorWithTupleSupport.TYPE_CHECKER),
 )
 
 
@@ -107,7 +80,7 @@ def import_json_schema(filename):
     try:
         with open(filename, "r") as f:
             jsn = json.load(f)
-        return Draft7ValidatorWithTupleAndDateTimeSupport(jsn)
+        return Draft7ValidatorWithTupleSupport(jsn, format_checker=jsonschema.draft7_format_checker)
     except ValueError as e:
         # I want missing/failing json imports to be an import error because that
         # is what they should indicate: a "broken" library

--- a/gcapi/gcapi.py
+++ b/gcapi/gcapi.py
@@ -133,14 +133,14 @@ class APIBase(object):
         for k, api in list(self.sub_apis.items()):
             setattr(self, k, api(self._client))
 
-    def __verify_against_schema(self, value):
+    def _verify_against_schema(self, value):
         if self.json_schema is not None:
             self.json_schema.validate(value)
 
     def list(self):
         result = self._client(method="GET", path=self.base_path)
         for i in result:
-            self.__verify_against_schema(i)
+            self._verify_against_schema(i)
         return result
 
     def page(self, offset=0, limit=100):
@@ -148,7 +148,7 @@ class APIBase(object):
             method="GET", path=self.base_path, params={"offset": offset, "limit": limit}
         )["results"]
         for i in result:
-            self.__verify_against_schema(i)
+            self._verify_against_schema(i)
         return result
 
     def iterate_all(self):
@@ -164,7 +164,7 @@ class APIBase(object):
 
     def detail(self, pk):
         result = self._client(method="GET", path=urljoin(self.base_path, pk + "/"))
-        self.__verify_against_schema(result)
+        self._verify_against_schema(result)
         return result
 
 
@@ -266,6 +266,12 @@ class RetinaLandmarkAnnotationSetsAPI(APIBase, ModifiableMixin):
     base_path = "retina/landmark-annotation/"
     json_schema = import_json_schema("landmark-annotation.json")
     modify_json_schema = import_json_schema("post-landmark-annotation.json")
+
+    def for_image(self, pk):
+        result = self._client(method="GET", path=self.base_path, params={"image_id": pk})
+        for i in result:
+            self._verify_against_schema(i)
+        return result
 
 
 class ChunkedUploadsAPI(APIBase):

--- a/gcapi/gcapi.py
+++ b/gcapi/gcapi.py
@@ -54,8 +54,9 @@ def accept_datetime_string(org):
 
     """
     return org.redefine(
-        "datetime", lambda checker, instance: isinstance(instance, str)
-        and validate_rfc3339(instance)
+        "datetime",
+        lambda checker, instance: isinstance(instance, str)
+        and validate_rfc3339(instance),
     )
 
 
@@ -268,7 +269,9 @@ class RetinaLandmarkAnnotationSetsAPI(APIBase, ModifiableMixin):
     modify_json_schema = import_json_schema("post-landmark-annotation.json")
 
     def for_image(self, pk):
-        result = self._client(method="GET", path=self.base_path, params={"image_id": pk})
+        result = self._client(
+            method="GET", path=self.base_path, params={"image_id": pk}
+        )
         for i in result:
             self._verify_against_schema(i)
         return result

--- a/gcapi/gcapi.py
+++ b/gcapi/gcapi.py
@@ -40,15 +40,28 @@ Draft7ValidatorWithTupleSupport = jsonschema.validators.extend(
 )
 
 
-def accept_datetime(org):
+def accept_datetime_string(org):
+    """
+    Adds support for validation of datetime strings in schemas by adding a new value
+    for the `type` key in schemas called `datetime`. Instances validated using this
+    type will be
+    Parameters
+    ----------
+    org
+
+    Returns
+    -------
+
+    """
     return org.redefine(
-        "datetime", lambda checker, instance: validate_rfc3339(instance)
+        "datetime", lambda checker, instance: isinstance(instance, str)
+        and validate_rfc3339(instance)
     )
 
 
 Draft7ValidatorWithTupleAndDateTimeSupport = jsonschema.validators.extend(
     Draft7ValidatorWithTupleSupport,
-    type_checker=accept_datetime(Draft7ValidatorWithTupleSupport.TYPE_CHECKER),
+    type_checker=accept_datetime_string(Draft7ValidatorWithTupleSupport.TYPE_CHECKER),
 )
 
 

--- a/gcapi/gcapi.py
+++ b/gcapi/gcapi.py
@@ -262,6 +262,12 @@ class AlgorithmJobsAPI(APIBase):
     base_path = "algorithms/jobs/"
 
 
+class RetinaLandmarkAnnotationSetsAPI(APIBase, ModifiableMixin):
+    base_path = "retina/landmark-annotation/"
+    json_schema = import_json_schema("landmark-annotation.json")
+    modify_json_schema = import_json_schema("post-landmark-annotation.json")
+
+
 class ChunkedUploadsAPI(APIBase):
     base_path = "chunked-uploads/"
 
@@ -382,6 +388,7 @@ class Client(Session):
         self.algorithm_results = AlgorithmResultsAPI(client=self)
         self.algorithm_jobs = AlgorithmJobsAPI(client=self)
         self.workstation_configs = WorkstationConfigsAPI(client=self)
+        self.retina_landmark_annotations = RetinaLandmarkAnnotationSetsAPI(client=self)
 
     @property
     def base_url(self):

--- a/gcapi/schemas/landmark-annotation.json
+++ b/gcapi/schemas/landmark-annotation.json
@@ -1,0 +1,53 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "uuid": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+        },
+        "single-landmark-annotation": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "$ref": "#/definitions/uuid"
+                },
+                "image": {
+                    "$ref": "#/definitions/uuid"
+                },
+                "landmarks": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {"type": "number"},
+                        "minItems": 2,
+                        "maxItems": 2
+                    },
+                    "minItems": 0
+                }
+            },
+            "required": ["id", "image", "landmarks"]
+        },
+        "landmark-annotation-set": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "$ref": "#/definitions/uuid"
+                },
+                "grader": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "created": {
+                    "type": "datetime"
+                },
+                "singlelandmarkannotation_set": {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/single-landmark-annotation" }
+                }
+            },
+            "required": ["id", "grader", "created", "singlelandmarkannotation_set"]
+        }
+     },
+
+    "$ref": "#/definitions/landmark-annotation-set"
+}

--- a/gcapi/schemas/landmark-annotation.json
+++ b/gcapi/schemas/landmark-annotation.json
@@ -38,7 +38,8 @@
                     "minimum": 0
                 },
                 "created": {
-                    "type": "datetime"
+                    "type": "string",
+                    "format": "date-time"
                 },
                 "singlelandmarkannotation_set": {
                     "type": "array",

--- a/gcapi/schemas/post-landmark-annotation.json
+++ b/gcapi/schemas/post-landmark-annotation.json
@@ -46,7 +46,7 @@
                     "items": { "$ref": "#/definitions/single-landmark-annotation" }
                 }
             },
-            "required": ["grader", "singlelandmarkannotation_set"]
+            "required": ["singlelandmarkannotation_set"]
         }
      },
 

--- a/gcapi/schemas/post-landmark-annotation.json
+++ b/gcapi/schemas/post-landmark-annotation.json
@@ -1,0 +1,53 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "uuid": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+        },
+        "single-landmark-annotation": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "$ref": "#/definitions/uuid"
+                },
+                "image": {
+                    "$ref": "#/definitions/uuid"
+                },
+                "landmarks": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {"type": "number"},
+                        "minItems": 2,
+                        "maxItems": 2
+                    },
+                    "minItems": 0
+                }
+            },
+            "required": ["image", "landmarks"]
+        },
+        "landmark-annotation-set": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "$ref": "#/definitions/uuid"
+                },
+                "grader": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "created": {
+                    "type": "datetime"
+                },
+                "singlelandmarkannotation_set": {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/single-landmark-annotation" }
+                }
+            },
+            "required": ["grader", "singlelandmarkannotation_set"]
+        }
+     },
+
+    "$ref": "#/definitions/landmark-annotation-set"
+}

--- a/gcapi/schemas/post-landmark-annotation.json
+++ b/gcapi/schemas/post-landmark-annotation.json
@@ -38,7 +38,8 @@
                     "minimum": 0
                 },
                 "created": {
-                    "type": "datetime"
+                    "type": "string",
+                    "format": "date-time"
                 },
                 "singlelandmarkannotation_set": {
                     "type": "array",

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,7 @@ with open("HISTORY.rst") as history_file:
 requirements = [
     "Click>=6.0",
     "Requests",
-    "jsonschema>=3.0",
-    "rfc3339-validator>=0.1.2",
+    "jsonschema[format_nongpl]>=3.0",
     "future>=0.17.1",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,13 @@ with open("README.rst") as readme_file:
 with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
-requirements = ["Click>=6.0", "Requests", "jsonschema>=3.0", "future>=0.17.1"]
+requirements = [
+    "Click>=6.0",
+    "Requests",
+    "jsonschema>=3.0",
+    "rfc3339-validator>=0.1.2",
+    "future>=0.17.1",
+]
 
 setup_requirements = ["pytest-runner"]
 

--- a/tests/test_gcapi.py
+++ b/tests/test_gcapi.py
@@ -7,6 +7,7 @@ import os
 import pytest
 
 from click.testing import CliRunner
+from jsonschema import ValidationError
 from requests.exceptions import HTTPError
 
 from gcapi import Client
@@ -92,6 +93,60 @@ def test_local_response():
     )
     # Empty response, but it didn't error out so the server is responding
     assert c.algorithms.page() == []
+
+
+@pytest.mark.parametrize(
+    "datetime_string,valid",
+    (
+        ("teststring", False),
+        (1, False),
+        ({}, False),
+        ("2019-13-11T13:55:00.123456Z", False),
+        ("2019-12-11T25:55:00.123456Z", False),
+        ("2019-12-11T13:60:00.123456Z", False),
+        ("2019-12-11T13:55:00.123456Z", True),
+        ("2019-12-11T13:55:00Z", True),
+    ),
+)
+def test_datetime_string_format_validation(datetime_string, valid):
+    landmark_annotation = {
+        "id": "4d5721f8-485d-4a17-8507-e06a8f897dd3",
+        "grader": 7,
+        "created": datetime_string,
+        "singlelandmarkannotation_set": [
+            {
+                "id": "69ea96c2-9a96-4080-9b2c-0b9d0417dda1",
+                "image": "70ec13fd-7fcf-4c84-bcd0-5fa3ac34a6b0",
+                "landmarks": [
+                    [249.029700179422, 194.950491966439],
+                    [308.910901038675, 210.158411188267],
+                    [270.891081357472, 353.683160558702],
+                ],
+            },
+            {
+                "id": "8055d041-d78d-4fa6-94af-1e57e80e11d8",
+                "image": "46ba46f4-7fcd-418d-a43f-f668b286daeb",
+                "landmarks": [
+                    [759.567661360211, 495.505389057573],
+                    [911.79182925945, 646.176269350096],
+                    [672.582428997143, 726.948261175343],
+                ],
+            },
+        ],
+    }
+    c = Client(
+        base_url="https://gc.localhost/api/v1/",
+        verify=False,
+        token="f1f98a1733c05b12118785ffd995c250fe4d90da",  # retina token
+    )
+    if valid:
+        assert (
+            c.retina_landmark_annotations._verify_against_schema(landmark_annotation)
+            is None
+        )
+    else:
+        with pytest.raises(ValidationError):
+            c.retina_landmark_annotations._verify_against_schema(landmark_annotation)
 
 
 def test_list_landmark_annotations():

--- a/tests/test_gcapi.py
+++ b/tests/test_gcapi.py
@@ -11,7 +11,6 @@ from requests.exceptions import HTTPError
 
 from gcapi import Client
 from gcapi import cli
-from gcapi.gcapi import Draft7ValidatorWithTupleAndDateTimeSupport
 
 
 def test_no_auth_exception():
@@ -93,24 +92,6 @@ def test_local_response():
     )
     # Empty response, but it didn't error out so the server is responding
     assert c.algorithms.page() == []
-
-
-@pytest.mark.parametrize(
-    "datetime_string,valid",
-    (
-        ("teststring", False),
-        (1, False),
-        ({}, False),
-        ("2019-13-11T13:55:00.123456Z", False),
-        ("2019-12-11T25:55:00.123456Z", False),
-        ("2019-12-11T13:60:00.123456Z", False),
-        ("2019-12-11T13:55:00.123456Z", True),
-        ("2019-12-11T13:55:00Z", True),
-    ),
-)
-def test_datetime_string_type_support(datetime_string, valid):
-    validator = Draft7ValidatorWithTupleAndDateTimeSupport({"type": "datetime"})
-    assert validator.is_valid(datetime_string) == valid
 
 
 def test_list_landmark_annotations():

--- a/tests/test_gcapi.py
+++ b/tests/test_gcapi.py
@@ -11,6 +11,7 @@ from requests.exceptions import HTTPError
 
 from gcapi import Client
 from gcapi import cli
+from gcapi.gcapi import Draft7ValidatorWithTupleAndDateTimeSupport
 
 
 def test_no_auth_exception():
@@ -92,3 +93,21 @@ def test_local_response():
     )
     # Empty response, but it didn't error out so the server is responding
     assert c.algorithms.page() == []
+
+
+@pytest.mark.parametrize(
+    "datetime_string,valid",
+    (
+        ("teststring", False),
+        (1, False),
+        ({}, False),
+        ("2019-13-11T13:55:00.123456Z", False),
+        ("2019-12-11T25:55:00.123456Z", False),
+        ("2019-12-11T13:60:00.123456Z", False),
+        ("2019-12-11T13:55:00.123456Z", True),
+        ("2019-12-11T13:55:00Z", True),
+    ),
+)
+def test_datetime_string_type_support(datetime_string, valid):
+    validator = Draft7ValidatorWithTupleAndDateTimeSupport({"type": "datetime"})
+    assert validator.is_valid(datetime_string) == valid

--- a/tests/test_gcapi.py
+++ b/tests/test_gcapi.py
@@ -133,14 +133,8 @@ def test_create_landmark_annotation():
     create_data = {
         "grader": 0,
         "singlelandmarkannotation_set": [
-            {
-                "image": nil_uuid,
-                "landmarks": [[0, 0], [1, 1], [2, 2]],
-            },
-            {
-                "image": nil_uuid,
-                "landmarks": [[0, 0], [1, 1], [2, 2]],
-            },
+            {"image": nil_uuid, "landmarks": [[0, 0], [1, 1], [2, 2]]},
+            {"image": nil_uuid, "landmarks": [[0, 0], [1, 1], [2, 2]]},
         ],
     }
     with pytest.raises(HTTPError) as e:
@@ -150,7 +144,6 @@ def test_create_landmark_annotation():
     response = response.json()
     assert response["grader"][0] == 'Invalid pk "0" - object does not exist.'
     for sla_error in response["singlelandmarkannotation_set"]:
-        assert (
-            sla_error["image"][0]
-            == 'Invalid pk "{}" - object does not exist.'.format(nil_uuid)
-        )
+        assert sla_error["image"][
+            0
+        ] == 'Invalid pk "{}" - object does not exist.'.format(nil_uuid)


### PR DESCRIPTION
- Adds `datetime` support for jsonschema using `rfc3339-validator`
- Adds support for `create`, `update`, `partial_update`, `delete` and `list` methods on clients
- Adds `RetinaLandmarkAnnotationSetsAPI` with support for `for_image` method (ListAPIView with special `image_id` parameter)
- Adds modify and normal JSONSchemas for `LanmarkAnnotationSet`
- Adds basic tests for `RetinaLandmarkAnnotationSetsAPI` and datetime support