### PR TITLE
Only serialize and return json if content type header corresponds

### DIFF
--- a/gcapi/gcapi.py
+++ b/gcapi/gcapi.py
@@ -433,4 +433,7 @@ class Client(Session):
             json=json,
         )
         response.raise_for_status()
-        return response.json()
+        if response.headers.get("Content-Type") == "application/json":
+            return response.json()
+        else:
+            return response


### PR DESCRIPTION
A `DELETE` request throws a `JSONDecodeError` because the response is empty and cannot be serialized as JSON. Therefore, only serialize JSON when the response headers indicate that the content is JSON. 