### PR TITLE
Implement ground_truth getter through APIBase

### DIFF
--- a/gcapi/gcapi.py
+++ b/gcapi/gcapi.py
@@ -1,6 +1,7 @@
 import itertools
 import os
 import uuid
+import warnings
 from collections import UserDict
 from io import BytesIO
 from json import load
@@ -286,10 +287,11 @@ class ReaderStudiesAPI(APIBase):
         return result
 
     def ground_truth(self, pk, case_pk):
-        print(
-            "GCAPI DEPRECATION WARNING: Please use "
-            "reader_studies.detail(pk).ground_truth.detail(case_pk) instead of "
-            "reader_studies.ground_truth(self, pk, case_pk)"
+        warnings.warn(
+            DeprecationWarning(
+                "Please use reader_studies.detail(pk).ground_truth.detail(case_pk) "
+                "instead of reader_studies.ground_truth(self, pk, case_pk)"
+            )
         )
         return self.detail(pk).ground_truth.detail(case_pk)
 

--- a/gcapi/gcapi.py
+++ b/gcapi/gcapi.py
@@ -95,7 +95,7 @@ def import_json_schema(filename):
     )
 
     try:
-        with open(filename, "r") as f:
+        with open(filename) as f:
             jsn = load(f)
         return Draft7ValidatorWithTupleSupport(
             jsn, format_checker=jsonschema.draft7_format_checker
@@ -157,8 +157,7 @@ class APIBase:
             )
             if len(current_list) == 0:
                 break
-            for item in current_list:
-                yield item
+            yield from current_list
             offset += req_count
 
     def detail(self, pk):
@@ -301,7 +300,7 @@ class GroundTruthAPI(APIBase):
             ReaderStudiesAPI.base_path, f"{pk}/ground-truth/"
         )
 
-        super(GroundTruthAPI, self).__init__(client)
+        super().__init__(client)
 
 
 class AlgorithmsAPI(APIBase):

--- a/gcapi/gcapi.py
+++ b/gcapi/gcapi.py
@@ -281,7 +281,7 @@ class ReaderStudiesAPI(APIBase):
     questions = None  # type: ReaderStudyQuestionsAPI
 
     def detail(self, pk):
-        result = LazyDict(lambda: super(ReaderStudiesAPI, self).detail(pk))
+        result = LazyDict(lambda: super().detail(pk))
         result.ground_truth = GroundTruthAPI(self._client, pk)
         return result
 

--- a/tests/test_gcapi.py
+++ b/tests/test_gcapi.py
@@ -3,6 +3,15 @@ from click.testing import CliRunner
 from jsonschema import ValidationError
 
 from gcapi import Client, cli
+from gcapi.gcapi import LazyDict
+
+
+def test_lazy_dict():
+    ld = LazyDict(lambda: {1: 2})
+    assert len(ld) == 1
+
+    ld = LazyDict(lambda: {1: 2})
+    assert ld[1] == 2
 
 
 def test_no_auth_exception():


### PR DESCRIPTION
* Add a LazyDict type that behaves like a dictionary but defers loading
  of the data to a later moment. The advantage here is that this allows us
  to attach extra functions to the detail view that might not require getting
  the actual object.
* Add the ground_truth detail view to the reader-study detail view
  that allows to query ground_truth data for a reader study
* Deprecate old method which bypassed the APIBase way of interactin
  with grand-challenge. I left it in there for now with a print-warning
  which we can remove later on.

Fixes #49

-------------------


This will allow us do consolidate the cirrus code:

~~~~~.py
        rs = gc_client.reader_studies
        [...]
        ground_truth = rs.ground_truth(self.study_id, pk)
~~~~~

to 

~~~~~.py
        ground_truth = self.reader_study.ground_truth.detail(pk)
~~~~~

Also this can serve as an example how this can be implemented for other recursive detail views in the future. We should likely flesh this out a bit more then.