### PR TITLE
Patch token from env

### DIFF
--- a/gcapi/gcapi.py
+++ b/gcapi/gcapi.py
@@ -465,7 +465,7 @@ class Client(Session):
         if token:
             self.headers.update({"Authorization": f"TOKEN {token}"})
         else:
-            token = os.getenv("GRAND_CHALLENGE_AUTHORIZATION")
+            token = str(os.getenv("GRAND_CHALLENGE_AUTHORIZATION", ""))
             if token:
                 # Already contains TOKEN prefix
                 self.headers.update({"Authorization": token})

--- a/gcapi/gcapi.py
+++ b/gcapi/gcapi.py
@@ -465,7 +465,12 @@ class Client(Session):
         if token:
             self.headers.update({"Authorization": f"TOKEN {token}"})
         else:
-            raise RuntimeError("Token must be set")
+            token = os.getenv("GRAND_CHALLENGE_AUTHORIZATION")
+            if token:
+                # Already contains TOKEN prefix
+                self.headers.update({"Authorization": token})
+            else:
+                raise RuntimeError("Token must be set")
 
         self._base_url = base_url
         if not self._base_url.startswith("https://"):

--- a/tests/test_gcapi.py
+++ b/tests/test_gcapi.py
@@ -1,4 +1,5 @@
 import pytest
+import os
 from click.testing import CliRunner
 from jsonschema import ValidationError
 

--- a/tests/test_gcapi.py
+++ b/tests/test_gcapi.py
@@ -26,6 +26,13 @@ def test_headers():
     assert c.headers["Accept"] == "application/json"
 
 
+def test_token_via_env_var():
+    token = "TOKEN 1b9436200001f2eaf57cd77db075cbb60a49a00a"
+    os.environ["GRAND_CHALLENGE_AUTHORIZATION"] = token
+    c = Client()
+    assert c.headers["Authorization"] == token
+
+
 def test_http_base_url():
     with pytest.raises(RuntimeError):
         Client(token="foo", base_url="http://example.com")

--- a/tests/test_gcapi.py
+++ b/tests/test_gcapi.py
@@ -1,5 +1,6 @@
-import pytest
 import os
+
+import pytest
 from click.testing import CliRunner
 from jsonschema import ValidationError
 


### PR DESCRIPTION
If one gets the token injected as env var GRAND_CHALLENGE_AUTHORIZATION, I as a user of Client does not want to read it and strip 'TOKEN ' in order to use it as token arg. Instead let Client read from env var when token arg is not given