### PR TITLE
Revert "Implement ground_truth getter through APIBase"

### DIFF
--- a/gcapi/gcapi.py
+++ b/gcapi/gcapi.py
@@ -1,8 +1,6 @@
 import itertools
 import os
 import uuid
-import warnings
-from collections import UserDict
 from io import BytesIO
 from json import load
 from pathlib import Path
@@ -38,23 +36,6 @@ Draft7ValidatorWithTupleSupport = jsonschema.validators.extend(
         jsonschema.Draft7Validator.TYPE_CHECKER
     ),
 )
-
-
-class LazyDict(UserDict):
-    def __init__(self, load_function):
-        self.__load_function = load_function
-        self.__data_loaded = False
-        self.__data = None
-
-    def load(self):
-        if not self.__data_loaded:
-            self.__data = self.__load_function()
-            self.__data_loaded = True
-
-    @property
-    def data(self):
-        self.load()
-        return self.__data
 
 
 def load_input_data(input_file):
@@ -96,7 +77,7 @@ def import_json_schema(filename):
     )
 
     try:
-        with open(filename) as f:
+        with open(filename, "r") as f:
             jsn = load(f)
         return Draft7ValidatorWithTupleSupport(
             jsn, format_checker=jsonschema.draft7_format_checker
@@ -158,7 +139,8 @@ class APIBase:
             )
             if len(current_list) == 0:
                 break
-            yield from current_list
+            for item in current_list:
+                yield item
             offset += req_count
 
     def detail(self, pk):
@@ -281,28 +263,12 @@ class ReaderStudiesAPI(APIBase):
     answers = None  # type: ReaderStudyAnswersAPI
     questions = None  # type: ReaderStudyQuestionsAPI
 
-    def detail(self, pk):
-        result = LazyDict(lambda: super().detail(pk))
-        result.ground_truth = GroundTruthAPI(self._client, pk)
-        return result
-
     def ground_truth(self, pk, case_pk):
-        warnings.warn(
-            DeprecationWarning(
-                "Please use reader_studies.detail(pk).ground_truth.detail(case_pk) "
-                "instead of reader_studies.ground_truth(self, pk, case_pk)"
-            )
+        result = self._client(
+            method="GET",
+            path=urljoin(self.base_path, pk + "/ground-truth/" + case_pk),
         )
-        return self.detail(pk).ground_truth.detail(case_pk)
-
-
-class GroundTruthAPI(APIBase):
-    def __init__(self, client, pk):
-        self.base_path = urljoin(
-            ReaderStudiesAPI.base_path, f"{pk}/ground-truth/"
-        )
-
-        super().__init__(client)
+        return result
 
 
 class AlgorithmsAPI(APIBase):

--- a/tests/test_gcapi.py
+++ b/tests/test_gcapi.py
@@ -5,15 +5,6 @@ from click.testing import CliRunner
 from jsonschema import ValidationError
 
 from gcapi import Client, cli
-from gcapi.gcapi import LazyDict
-
-
-def test_lazy_dict():
-    ld = LazyDict(lambda: {1: 2})
-    assert len(ld) == 1
-
-    ld = LazyDict(lambda: {1: 2})
-    assert ld[1] == 2
 
 
 def test_no_auth_exception():


### PR DESCRIPTION
Reverts DIAGNijmegen/rse-gcapi#52 as calling `client.reader_studies.detail(pk=readerStudyPK)` results in `super(): no arguments`.