### PR TITLE
Refactors upload_cases

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,9 +2,13 @@
 History
 =======
 
-0.2.10 (2020-11-23)
--------------------
+0.3.x (unreleased)
+------------------
 
+* Breaking Changes in ``upload_cases``: 
+  * Renamed kwarg ``files_to_upload`` to ``files``
+  * ``algorithm`` kwarg now takes a ``slug`` rather than a ``title``
+  * Removed ``run_external_algorithm``, use ``upload_cases`` instead
 * Add Multiple 2D bounding box question types to reader studies
 
 0.2.9 (2020-09-29)

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,50 @@ Python client for the grand-challenge.org API
 Features
 --------
 
-* TODO
+This client library is a handy way to interact with the REST API for grand-challenge.org from python, and provides some convenience methods.
+
+Uploading Files to Archives, Algorithms or Reader Studies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You will need to get an API token, and find the slug of the object you want to upload to.
+
+
+First, you will need to authorise the client using your personal API token.
+
+.. code:: python
+
+    from gcapi import Client
+    
+    c = Client(token="Your personal API Token")
+
+Then, prepare the list of files you want to upload.
+
+.. code:: python
+
+    from pathlib import Path
+    
+    files = [f.resolve() for f in Path("/path/to/files").iterdir()]
+
+Now, you can upload these files to an Archive, Algorithm or Reader Study which are identified by a slug.
+For instance, if you would like to upload to the algorithm at https://grand-challenge.org/algorithms/corads-ai/ you would use ``algorithm="corads-ai"``.
+Note that this is case sensitive.
+
+Now you can start the upload.
+
+.. code:: python
+
+    session = c.upload_cases(files=files, algorithm="corads-ai")
+
+You can change ``algorithm`` for ``archive`` or ``reader_study`` there.
+
+You will get a session that starts the conversion of the files, and then adds the standardised images to the selected object once it has succeeded.
+You can refresh the session object with
+
+.. code:: python
+
+    session = c(url=session["api_url"])
+
+and check the session status with ``session["status"]``.
 
 Credits
 -------

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ First, you will need to authorise the client using your personal API token.
     
     c = Client(token="Your personal API Token")
 
-Then, prepare the list of files you want to upload.
+Then, prepare the list of files for each image you want to upload.
 
 .. code:: python
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,15 @@ def local_grand_challenge() -> Generator[str, None, None]:
                         cwd=tmp_path,
                     )
                 check_call(
-                    ["docker-compose", "up", "-d", "http"], cwd=tmp_path
+                    [
+                        "docker-compose",
+                        "up",
+                        "-d",
+                        "http",
+                        "celery_worker",
+                        "celery_worker_evaluation",
+                    ],
+                    cwd=tmp_path,
                 )
                 check_call(
                     ["docker-compose-wait", "-w", "-t", "5m"], cwd=tmp_path


### PR DESCRIPTION
This PR refactors the case upload helper functions, using slugs for consistency and removing duplicated functionality.

The tests will fail until https://github.com/comic/grand-challenge.org/pull/1626 is merged to master, and this should be released as soon as that PR is deployed.

Closes #65 

TODO for the future: we should check that the object that the user wants to upload to is correct before starting the upload session, check that the files exist, and the memory usage of the file uploads does not look great here either.