### PR TITLE
Normalise token header

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,6 @@ def local_grand_challenge() -> Generator[str, None, None]:
 
                 for command in [
                     "migrate",
-                    "check_permissions",
                     "init_gc_demo",
                 ]:
                     check_call(

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -13,7 +13,9 @@ ALGORITHMUSER_TOKEN = "dc3526c2008609b429514b6361a33f8516541464"
 READERSTUDY_TOKEN = "01614a77b1c0b4ecd402be50a8ff96188d5b011d"
 
 
-@pytest.mark.xfail("https://github.com/comic/grand-challenge.org/pull/1740")
+@pytest.mark.xfail(
+    reason="Awaiting https://github.com/comic/grand-challenge.org/pull/1740"
+)
 @pytest.mark.parametrize(
     "annotation",
     [
@@ -30,7 +32,9 @@ def test_list_annotations(local_grand_challenge, annotation):
     assert len(response) == 0
 
 
-@pytest.mark.xfail("https://github.com/comic/grand-challenge.org/pull/1740")
+@pytest.mark.xfail(
+    reason="Awaiting https://github.com/comic/grand-challenge.org/pull/1740"
+)
 def test_create_landmark_annotation(local_grand_challenge):
     c = Client(
         base_url=local_grand_challenge, verify=False, token=RETINA_TOKEN
@@ -56,7 +60,9 @@ def test_create_landmark_annotation(local_grand_challenge):
         )
 
 
-@pytest.mark.xfail("https://github.com/comic/grand-challenge.org/pull/1740")
+@pytest.mark.xfail(
+    reason="Awaiting https://github.com/comic/grand-challenge.org/pull/1740"
+)
 def test_create_polygon_annotation_set(local_grand_challenge):
     c = Client(
         base_url=local_grand_challenge, verify=False, token=RETINA_TOKEN
@@ -83,7 +89,9 @@ def test_create_polygon_annotation_set(local_grand_challenge):
     assert response["name"][0] == "This field is required."
 
 
-@pytest.mark.xfail("https://github.com/comic/grand-challenge.org/pull/1740")
+@pytest.mark.xfail(
+    reason="Awaiting https://github.com/comic/grand-challenge.org/pull/1740"
+)
 def test_create_single_polygon_annotations(local_grand_challenge):
     c = Client(
         base_url=local_grand_challenge, verify=False, token=RETINA_TOKEN

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -13,6 +13,7 @@ ALGORITHMUSER_TOKEN = "dc3526c2008609b429514b6361a33f8516541464"
 READERSTUDY_TOKEN = "01614a77b1c0b4ecd402be50a8ff96188d5b011d"
 
 
+@pytest.mark.xfail("https://github.com/comic/grand-challenge.org/pull/1740")
 @pytest.mark.parametrize(
     "annotation",
     [
@@ -29,6 +30,7 @@ def test_list_annotations(local_grand_challenge, annotation):
     assert len(response) == 0
 
 
+@pytest.mark.xfail("https://github.com/comic/grand-challenge.org/pull/1740")
 def test_create_landmark_annotation(local_grand_challenge):
     c = Client(
         base_url=local_grand_challenge, verify=False, token=RETINA_TOKEN
@@ -54,6 +56,7 @@ def test_create_landmark_annotation(local_grand_challenge):
         )
 
 
+@pytest.mark.xfail("https://github.com/comic/grand-challenge.org/pull/1740")
 def test_create_polygon_annotation_set(local_grand_challenge):
     c = Client(
         base_url=local_grand_challenge, verify=False, token=RETINA_TOKEN
@@ -80,6 +83,7 @@ def test_create_polygon_annotation_set(local_grand_challenge):
     assert response["name"][0] == "This field is required."
 
 
+@pytest.mark.xfail("https://github.com/comic/grand-challenge.org/pull/1740")
 def test_create_single_polygon_annotations(local_grand_challenge):
     c = Client(
         base_url=local_grand_challenge, verify=False, token=RETINA_TOKEN

--- a/tests/test_gcapi.py
+++ b/tests/test_gcapi.py
@@ -5,9 +5,12 @@ from jsonschema import ValidationError
 from gcapi import Client, cli
 
 
-def test_no_auth_exception():
+@pytest.mark.parametrize(
+    "kwargs", ({}, {"token": ""}, {"token": "not a token"})
+)
+def test_no_auth_exception(kwargs):
     with pytest.raises(RuntimeError):
-        Client()
+        Client(**kwargs)
 
 
 def test_headers():
@@ -36,6 +39,8 @@ def test_token_precidence(monkeypatch):
         "qwerty",
         "TOKEN qwerty",
         "BEARER qwerty",
+        "Bearer qwerty",
+        "bearer qwerty",
         "whatever qwerty",
         "  TOKEN   qwerty    ",
     ],


### PR DESCRIPTION
We currently support two methods of specifying the authentication token, through arguments and through the environment variable, and two formats for the token `token` and `bearer`. This standardises all methods of setting the token, and will always produce a `bearer` token. 

`bearer` support is currently missing from the retina endpoints, but will be standardised in https://github.com/comic/grand-challenge.org/pull/1740. Updating CIRRUS is not required as it will pass the token without modification right now. This should be released to pypi alongside 1740.