### PR TITLE
Fix CI

### DIFF
--- a/gcapi/schemas/reader-study.json
+++ b/gcapi/schemas/reader-study.json
@@ -114,11 +114,18 @@
                     }
                 },
                 "hanging_list_images": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "additionalProperties": { "$ref": "#/definitions/api-link" }
-                    }
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": { "$ref": "#/definitions/api-link" }
+                            }
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 }
             },
             "required": [

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 testpaths= tests
 python_files = tests.py test_*.py *_tests.py
-addopts = --strict --showlocals
+addopts = --strict-markers --showlocals

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
-testpaths= tests
+testpaths = tests
 python_files = tests.py test_*.py *_tests.py
+xfail_strict = true
 addopts = --strict-markers --showlocals

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,11 +44,7 @@ def local_grand_challenge() -> Generator[str, None, None]:
                 check_call(["docker-compose", "pull"], cwd=tmp_path)
 
                 check_call(
-                    [
-                        "make",
-                        "development_fixtures",
-                    ],
-                    cwd=tmp_path,
+                    ["make", "development_fixtures"], cwd=tmp_path,
                 )
                 check_call(
                     [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,28 +35,21 @@ def local_grand_challenge() -> Generator[str, None, None]:
             for f in [
                 "docker-compose.yml",
                 "dockerfiles/db/postgres.test.conf",
+                "Makefile",
+                "scripts/development_fixtures.py",
             ]:
                 get_grand_challenge_file(Path(f), Path(tmp_path))
 
             try:
                 check_call(["docker-compose", "pull"], cwd=tmp_path)
 
-                for command in [
-                    "migrate",
-                    "init_gc_demo",
-                ]:
-                    check_call(
-                        [
-                            "docker-compose",
-                            "run",
-                            "--rm",
-                            "web",
-                            "python",
-                            "manage.py",
-                            command,
-                        ],
-                        cwd=tmp_path,
-                    )
+                check_call(
+                    [
+                        "make",
+                        "development_fixtures",
+                    ],
+                    cwd=tmp_path,
+                )
                 check_call(
                     [
                         "docker-compose",

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -13,9 +13,6 @@ ALGORITHMUSER_TOKEN = "dc3526c2008609b429514b6361a33f8516541464"
 READERSTUDY_TOKEN = "01614a77b1c0b4ecd402be50a8ff96188d5b011d"
 
 
-@pytest.mark.xfail(
-    reason="Awaiting https://github.com/comic/grand-challenge.org/pull/1740"
-)
 @pytest.mark.parametrize(
     "annotation",
     [
@@ -32,9 +29,6 @@ def test_list_annotations(local_grand_challenge, annotation):
     assert len(response) == 0
 
 
-@pytest.mark.xfail(
-    reason="Awaiting https://github.com/comic/grand-challenge.org/pull/1740"
-)
 def test_create_landmark_annotation(local_grand_challenge):
     c = Client(
         base_url=local_grand_challenge, verify=False, token=RETINA_TOKEN
@@ -60,9 +54,6 @@ def test_create_landmark_annotation(local_grand_challenge):
         )
 
 
-@pytest.mark.xfail(
-    reason="Awaiting https://github.com/comic/grand-challenge.org/pull/1740"
-)
 def test_create_polygon_annotation_set(local_grand_challenge):
     c = Client(
         base_url=local_grand_challenge, verify=False, token=RETINA_TOKEN
@@ -89,9 +80,6 @@ def test_create_polygon_annotation_set(local_grand_challenge):
     assert response["name"][0] == "This field is required."
 
 
-@pytest.mark.xfail(
-    reason="Awaiting https://github.com/comic/grand-challenge.org/pull/1740"
-)
 def test_create_single_polygon_annotations(local_grand_challenge):
     c = Client(
         base_url=local_grand_challenge, verify=False, token=RETINA_TOKEN
@@ -183,6 +171,6 @@ def test_upload_cases(local_grand_challenge, files):
     image = c(url=us["image_set"][0])
 
     # And that it was added to the reader study
-    assert len(image["reader_study_set"]) == 1
-    reader_study = c(url=image["reader_study_set"][0])
-    assert reader_study["slug"] == "reader-study"
+    rs = next(c.reader_studies.iterate_all(params={"slug": "reader-study"}))
+    rs_images = c.images.iterate_all(params={"reader_study": rs["pk"]})
+    assert image["pk"] in [im["pk"] for im in rs_images]

--- a/tox.ini
+++ b/tox.ini
@@ -12,4 +12,4 @@ setenv =
     PYTHONPATH = {toxinidir}
 extras = test
 commands =
-    py.test --cov-branch --cov-report= --cov=gcapi --basetemp={envtmpdir}
+    py.test --cov-branch --cov-report= --cov=gcapi --basetemp={envtmpdir} {posargs}


### PR DESCRIPTION
The way fixtures are generated for grand challenge was changed in https://github.com/comic/grand-challenge.org/pull/1851, we need to grab a couple of extra files here for the make command to work now. Also removes some xfail markers for tests which were passing after a PR merge in grand challenge and fixes the reader study schema as the hanging list has always been able to be null too.

#76 should be rebased on to this once on master.