### PR TITLE
Add a method for downloading images

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,8 @@
 History
 =======
 
+* Added ``client.images.download``
+
 0.5.0 (2021-11-01)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -164,6 +164,25 @@ You can refresh the session object with
 
 and check the session status with ``session["status"]``.
 
+Downloading Files
+-----------------
+
+An image can consist of one or multiple files, such as a single mha file or a dzi and tiff file. You can download all files
+associated with an image.
+
+.. code:: python
+
+    from pathlib import Path
+
+    downloaded_files = c.images.download(pk="...", filename=Path("path/to/output"))
+
+You can also use other parameters to identify the image, such as the API URL, and you can also supply the "files" list directly.
+
+... code:: python
+
+    image = c.images.detail(pk="...")
+    c.images.download(files=image["files"], filename=Path("path/to/output"))
+
 Credits
 -------
 

--- a/README.rst
+++ b/README.rst
@@ -168,7 +168,7 @@ Downloading Files
 -----------------
 
 An image can consist of one or multiple files, such as a single mha file or a dzi and tiff file. You can download all files
-associated with an image.
+associated with an image at once.
 
 .. code:: python
 
@@ -176,12 +176,16 @@ associated with an image.
 
     downloaded_files = c.images.download(pk="...", filename=Path("path/to/output"))
 
-You can also use other parameters to identify the image, such as the API URL, and you can also supply the "files" list directly.
+You can also use other parameters to identify the image, such as the API URL (use `url="..."`), and you can also supply the "files" list
+directly if you have already obtained the image details.
 
 ... code:: python
 
     image = c.images.detail(pk="...")
     c.images.download(files=image["files"], filename=Path("path/to/output"))
+
+Note that the filename needs to be specified without file extension. The extension is automatically added because multiple files with
+different file extensions can be assosicated with an image (dzi/tif and mhd/zraw for example).
 
 Credits
 -------

--- a/README.rst
+++ b/README.rst
@@ -167,7 +167,7 @@ and check the session status with ``session["status"]``.
 Downloading Files
 -----------------
 
-An image can consist of one or multiple files, such as a single mha file or a dzi and tiff file. You can download all files
+An image can consist of one or multiple files, such as a single mha file or a dzi and a tiff file. You can download all files
 associated with an image at once.
 
 .. code:: python
@@ -176,10 +176,10 @@ associated with an image at once.
 
     downloaded_files = c.images.download(pk="...", filename=Path("path/to/output"))
 
-You can also use other parameters to identify the image, such as the API URL (use `url="..."`), and you can also supply the "files" list
+You can also use other parameters to identify the image, such as the API URL (use ``url="..."``), and you can also supply the "files" list
 directly if you have already obtained the image details.
 
-... code:: python
+.. code:: python
 
     image = c.images.detail(pk="...")
     c.images.download(files=image["files"], filename=Path("path/to/output"))

--- a/gcapi/client.py
+++ b/gcapi/client.py
@@ -97,8 +97,8 @@ class ImagesAPI(APIBase):
     def download(
         self,
         *,
-        filename: Union[str, Path],
-        image_type: str = None,
+        filename: Union[str, Path],  # extension is added automatically
+        image_type: str = None,  # restrict download to a particular image type
         pk=None,
         url=None,
         files=None,

--- a/gcapi/client.py
+++ b/gcapi/client.py
@@ -4,9 +4,10 @@ import re
 import uuid
 from io import BytesIO
 from json import load
+from pathlib import Path
 from random import randint
 from time import sleep
-from typing import Any, Dict, Generator, List, TYPE_CHECKING
+from typing import Any, Dict, Generator, List, TYPE_CHECKING, Union
 from urllib.parse import urljoin
 
 import httpx
@@ -92,6 +93,60 @@ def import_json_schema(filename):
 
 class ImagesAPI(APIBase):
     base_path = "cases/images/"
+
+    def download(
+        self,
+        *,
+        filename: Union[str, Path],
+        image_type: str = None,
+        pk=None,
+        url=None,
+        files=None,
+        **params,
+    ):
+        if len([p for p in (pk, url, files, params) if p]) != 1:
+            raise ValueError(
+                "Exactly one of pk, url, files or params must be specified"
+            )
+
+        # Retrieve details of the image if needed
+        if files is None:
+            if pk is not None:
+                image = yield from self.detail(pk=pk)
+            elif url is not None:
+                image = yield self.yield_request(method="GET", url=url)
+                self.verify_against_schema(image)
+            else:
+                image = yield from self.detail(**params)
+
+            files = image["files"]
+
+        # Make sure file destination exists
+        p = Path(filename).absolute()
+        directory = p.parent
+        directory.mkdir(parents=True, exist_ok=True)
+        basename = p.name
+
+        # Download the files
+        downloaded_files = []
+        for file in files:
+            if image_type and file["image_type"] != image_type:
+                continue
+
+            data = (
+                yield self.yield_request(
+                    method="GET", url=file["file"], follow_redirects=True
+                )
+            ).content
+
+            suffix = file["file"].split(".")[-1]
+            local_file = directory / f"{basename}.{suffix}"
+            with local_file.open("wb") as fp:
+                fp.write(data)
+
+            downloaded_files.append(local_file)
+
+        return downloaded_files
 
 
 class UploadSessionFilesAPI(ModifiableMixin, APIBase):


### PR DESCRIPTION
Since downloading images and masks is a common task, I think it would be helpful to have a helper function that does that. A user might often have only the UUID of the image from the algorithm job details so that downloading the actual image requires multiple steps (query for list of files associated with the image, download the files).

I've implemented this, but I'm struggling a bit to understand the new structure with all these `yield` calls, so I'm not sure whether I've done that correctly (it works though, at least with the regular client).

This method could also be added to the Client class instead of the ImagesAPI, similar to the `upload_cases()` method.

I would appreciate some feedback regarding the two points above. Thanks!