### PR TITLE
Remove UploadSessionFilesAPI

### DIFF
--- a/gcapi/client.py
+++ b/gcapi/client.py
@@ -94,10 +94,6 @@ class ImagesAPI(APIBase):
     base_path = "cases/images/"
 
 
-class UploadSessionFilesAPI(ModifiableMixin, APIBase):
-    base_path = "cases/upload-sessions/files/"
-
-
 class UploadSessionsAPI(ModifiableMixin, APIBase):
     base_path = "cases/upload-sessions/"
 
@@ -392,7 +388,6 @@ class ApiDefinitions:
     retina_polygon_annotation_sets: RetinaPolygonAnnotationSetsAPI
     retina_single_polygon_annotations: RetinaSinglePolygonAnnotationsAPI
     retina_etdrs_grid_annotations: RetinaETDRSGridAnnotationsAPI
-    raw_image_upload_session_files: UploadSessionFilesAPI
     raw_image_upload_sessions: UploadSessionsAPI
 
 

--- a/tests/async_integration_tests.py
+++ b/tests/async_integration_tests.py
@@ -115,7 +115,6 @@ async def test_raw_image_and_upload_session(local_grand_challenge):
     async with AsyncClient(
         base_url=local_grand_challenge, verify=False, token=RETINA_TOKEN
     ) as c:
-        assert await c.raw_image_upload_session_files.page() == []
         assert await c.raw_image_upload_sessions.page() == []
 
 

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -104,7 +104,6 @@ def test_create_single_polygon_annotations(local_grand_challenge):
 
 def test_raw_image_and_upload_session(local_grand_challenge):
     c = Client(base_url=local_grand_challenge, verify=False, token=ADMIN_TOKEN)
-    assert c.raw_image_upload_session_files.page() == []
     assert c.raw_image_upload_sessions.page() == []
 
 


### PR DESCRIPTION
Since the corresponding endpoint has been removed (I suppose because files are now directly uploaded to S3) in https://github.com/comic/grand-challenge.org/pull/2154 I believe the UploadSessionFilesAPI can be removed.