### PR TITLE
Add isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,3 @@
-default_language_version:
-  python: python3.8
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0
@@ -15,6 +13,10 @@ repos:
       - id: pyupgrade
         language: python
         args: [--py36-plus]
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
   - repo: https://github.com/ambv/black
     rev: 22.1.0
     hooks:
@@ -27,7 +29,6 @@ repos:
         language: python
         additional_dependencies:
           - flake8-bugbear
-          - flake8-import-order
           - pep8-naming
           # The following is disabled due to a runtime error
           # - flake8-docstrings

--- a/gcapi/apibase.py
+++ b/gcapi/apibase.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, Generator, Optional, Type
 from urllib.parse import urljoin
 
 import jsonschema
-from httpx import HTTPStatusError, URL
+from httpx import URL, HTTPStatusError
 from httpx._types import URLTypes
 
 from .exceptions import MultipleObjectsReturned, ObjectNotFound

--- a/gcapi/client.py
+++ b/gcapi/client.py
@@ -7,13 +7,12 @@ from json import load
 from pathlib import Path
 from random import randint
 from time import sleep
-from typing import Any, Dict, Generator, List, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Dict, Generator, List, Union
 from urllib.parse import urljoin
 
 import httpx
 import jsonschema
-from httpx import HTTPStatusError
-from httpx import Timeout, URL
+from httpx import URL, HTTPStatusError, Timeout
 
 from gcapi.apibase import APIBase, ClientInterface, ModifiableMixin
 from gcapi.exceptions import ObjectNotFound

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,11 @@ docker-compose-wait = "*"
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
+[tool.isort]
+profile = "black"
+known_first_party = ["gcapi", "tests"]
+line_length = 79
+
 [tool.black]
 line-length = 79
 target-version = ['py36']

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,10 +3,6 @@ python_version = 3.6
 
 [flake8]
 max-line-length = 79
-application-import-names =
-    gcapi
-    tests
-import-order-style = pycharm
 docstring-convention = numpy
 max-complexity = 10
 select =


### PR DESCRIPTION
This PR adds isort with the following changes:

- [x] `default_language_version` removed
- [x] pyupgrade args set correctly
- [x] `isort` added before `black`
- [x] `flake8-import-order` removed
- [x] `known_first_party` set correctly
- [x] `application-import-names` and `import-order-style` removed