### PR TITLE
Provide access to the page meta information

### DIFF
--- a/tests/async_integration_tests.py
+++ b/tests/async_integration_tests.py
@@ -223,6 +223,21 @@ async def test_upload_cases_to_reader_study(local_grand_challenge, files):
         assert response.status_code == 200
 
 
+@pytest.mark.anyio
+async def test_page_meta(local_grand_challenge):
+    c = AsyncClient(
+        base_url=local_grand_challenge, verify=False, token=ARCHIVE_TOKEN
+    )
+    page_meta = {}
+
+    archives = c.archives.iterate_all(page_meta=page_meta)
+    assert len([item async for item in archives]) == page_meta["count"]
+
+    page_meta = {}
+    archives = await c.archives.page(page_meta=page_meta)
+    assert len(list(archives)) == page_meta["count"]
+
+
 @pytest.mark.parametrize(
     "files, interface",
     (

--- a/tests/async_integration_tests.py
+++ b/tests/async_integration_tests.py
@@ -225,17 +225,17 @@ async def test_upload_cases_to_reader_study(local_grand_challenge, files):
 
 @pytest.mark.anyio
 async def test_page_meta(local_grand_challenge):
-    c = AsyncClient(
+    async with AsyncClient(
         base_url=local_grand_challenge, verify=False, token=ARCHIVE_TOKEN
-    )
-    page_meta = {}
+    ) as c:
+        page_meta = {}
 
-    archives = c.archives.iterate_all(page_meta=page_meta)
-    assert len([item async for item in archives]) == page_meta["count"]
+        archives = c.archives.iterate_all(page_meta=page_meta)
+        assert len([item async for item in archives]) == page_meta["count"]
 
-    page_meta = {}
-    archives = await c.archives.page(page_meta=page_meta)
-    assert len(list(archives)) == page_meta["count"]
+        page_meta = {}
+        archives = await c.archives.page(page_meta=page_meta)
+        assert len(list(archives)) == page_meta["count"]
 
 
 @pytest.mark.parametrize(

--- a/tests/async_integration_tests.py
+++ b/tests/async_integration_tests.py
@@ -224,18 +224,16 @@ async def test_upload_cases_to_reader_study(local_grand_challenge, files):
 
 
 @pytest.mark.anyio
-async def test_page_meta(local_grand_challenge):
+async def test_page_meta_info(local_grand_challenge):
     async with AsyncClient(
         base_url=local_grand_challenge, verify=False, token=ARCHIVE_TOKEN
     ) as c:
-        page_meta = {}
+        archives = await c.archives.page(limit=123)
 
-        archives = c.archives.iterate_all(page_meta=page_meta)
-        assert len([item async for item in archives]) == page_meta["count"]
-
-        page_meta = {}
-        archives = await c.archives.page(page_meta=page_meta)
-        assert len(list(archives)) == page_meta["count"]
+        assert len(archives) == 1
+        assert archives.offset == 0
+        assert archives.limit == 123
+        assert archives.total_count == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -280,15 +280,16 @@ def test_upload_cases_to_archive_item_without_interface(local_grand_challenge):
     assert "You need to define an interface for archive item uploads" in str(e)
 
 
-@pytest.mark.parametrize("api_method_name", ("page", "iterate_all"))
-def test_page_meta(local_grand_challenge, api_method_name):
+def test_page_meta_info(local_grand_challenge):
     c = Client(
         base_url=local_grand_challenge, verify=False, token=ARCHIVE_TOKEN
     )
-    page_meta = {}
-    api_method = getattr(c.archives, api_method_name)
-    archives = api_method(page_meta=page_meta)
-    assert len(list(archives)) == page_meta["count"]
+    archives = c.archives.page(limit=123)
+
+    assert len(archives) == 1
+    assert archives.offset == 0
+    assert archives.limit == 123
+    assert archives.count == 1
 
 
 def test_upload_cases_to_archive_item_with_existing_interface(

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -289,7 +289,7 @@ def test_page_meta_info(local_grand_challenge):
     assert len(archives) == 1
     assert archives.offset == 0
     assert archives.limit == 123
-    assert archives.count == 1
+    assert archives.total_count == 1
 
 
 def test_upload_cases_to_archive_item_with_existing_interface(

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -280,6 +280,17 @@ def test_upload_cases_to_archive_item_without_interface(local_grand_challenge):
     assert "You need to define an interface for archive item uploads" in str(e)
 
 
+@pytest.mark.parametrize("api_method_name", ("page", "iterate_all"))
+def test_page_meta(local_grand_challenge, api_method_name):
+    c = Client(
+        base_url=local_grand_challenge, verify=False, token=ARCHIVE_TOKEN
+    )
+    page_meta = {}
+    api_method = getattr(c.archives, api_method_name)
+    archives = api_method(page_meta=page_meta)
+    assert len(list(archives)) == page_meta["count"]
+
+
 def test_upload_cases_to_archive_item_with_existing_interface(
     local_grand_challenge,
 ):


### PR DESCRIPTION
When calling the `.page()` of the APIBase I have a need to access the returned `"count"`.

I could get away with doing a custom page call via URL components to get these values, but then spoofing them in CIRRUS becomes a bit of a hassle and a mess.

The quickest way I could come up with, without changing the return values was to park the page meta data into a referenced dictionary.