### PR TITLE
Fix upload cases

### DIFF
--- a/gcapi/client.py
+++ b/gcapi/client.py
@@ -776,7 +776,7 @@ class ClientBase(ApiDefinitions, ClientInterface):
         First, retrieve the archive items from your archive:
         archive = next(client.archives.iterate_all(params={"slug": "..."}))
         items = list(
-            client.archive_items.iterate_all(params={"archive": archive["id"]})
+            client.archive_items.iterate_all(params={"archive": archive["pk"]})
         )
         To then add, for example, a PDF report and a lung volume
         value to the first archive item , provide the interface slugs together

--- a/gcapi/client.py
+++ b/gcapi/client.py
@@ -908,10 +908,10 @@ class ClientBase(ApiDefinitions, ClientInterface):
                         f"https://grand-challenge.org/algorithms/interfaces/"
                     ) from e
 
-                self.upload_cases(
+                yield from self._upload_files(
                     display_set=ds["pk"],
                     interface=interface,
-                    files=files,
+                    files=files
                 )
             res.append(ds["pk"])
         return res  # noqa: B901

--- a/gcapi/client.py
+++ b/gcapi/client.py
@@ -419,7 +419,7 @@ class UploadsAPI(APIBase):
                 if status_code in [409, 423] or status_code >= 500:
                     num_retries += 1
                     e = _e
-                    sleep((2**num_retries) + (randint(0, 1000) / 1000))
+                    sleep((2 ** num_retries) + (randint(0, 1000) / 1000))
                 else:
                     raise
         else:
@@ -909,9 +909,7 @@ class ClientBase(ApiDefinitions, ClientInterface):
                     ) from e
 
                 yield from self._upload_files(
-                    display_set=ds["pk"],
-                    interface=interface,
-                    files=files
+                    display_set=ds["pk"], interface=interface, files=files
                 )
             res.append(ds["pk"])
         return res  # noqa: B901

--- a/gcapi/client.py
+++ b/gcapi/client.py
@@ -419,7 +419,7 @@ class UploadsAPI(APIBase):
                 if status_code in [409, 423] or status_code >= 500:
                     num_retries += 1
                     e = _e
-                    sleep((2 ** num_retries) + (randint(0, 1000) / 1000))
+                    sleep((2**num_retries) + (randint(0, 1000) / 1000))
                 else:
                     raise
         else:

--- a/gcapi/client.py
+++ b/gcapi/client.py
@@ -594,14 +594,13 @@ class ClientBase(ApiDefinitions, ClientInterface):
         *,
         files: List[str],
         archive: str = None,
-        reader_study: str = None,
         answer: str = None,
         archive_item: str = None,
         display_set: str = None,
         interface: str = None,
     ):
         """
-        Uploads a set of files to an archive, archive item or reader study.
+        Uploads a set of files to an archive, archive item or display set.
         A new upload session will be created on grand challenge to import and
         standardise your file(s). This function will return this new upload
         session object, that you can query for the import status. If this
@@ -632,10 +631,10 @@ class ClientBase(ApiDefinitions, ClientInterface):
             The slug of the archive to use.
         archive_item
             The pk of the archive item to use.
-        reader_study
-            The slug of the reader study to use.
         answer
             The pk of the reader study answer to use.
+        display_set
+            The pk of the display set to use.
         interface
             The slug of the interface to use. Can only be defined for archive
             and archive item uploads.
@@ -647,9 +646,6 @@ class ClientBase(ApiDefinitions, ClientInterface):
 
         if len(files) == 0:
             raise ValueError("You must specify the files to upload")
-
-        if reader_study is not None:
-            upload_session_data["reader_study"] = reader_study
 
         if archive is not None:
             upload_session_data["archive"] = archive

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ testpaths = [
 python_files = "tests.py test_*.py *_tests.py"
 addopts = "--strict-markers --showlocals"
 xfail_strict = true
+filterwarnings = [
+    "error",
+]
 
 [tool.tox]
 legacy_tox_ini = """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,6 @@ testpaths = [
 python_files = "tests.py test_*.py *_tests.py"
 addopts = "--strict-markers --showlocals"
 xfail_strict = true
-filterwarnings = [
-    "error",
-]
 
 [tool.tox]
 legacy_tox_ini = """

--- a/tests/async_integration_tests.py
+++ b/tests/async_integration_tests.py
@@ -271,11 +271,11 @@ async def test_upload_cases_to_archive(
             c.archives.iterate_all(params={"slug": "archive"})
         ).__anext__()
         archive_images = c.images.iterate_all(
-            params={"archive": archive["id"]}
+            params={"archive": archive["pk"]}
         )
         assert image["pk"] in [im["pk"] async for im in archive_images]
         archive_items = c.archive_items.iterate_all(
-            params={"archive": archive["id"]}
+            params={"archive": archive["pk"]}
         )
 
         # with the correct interface
@@ -313,7 +313,7 @@ async def test_upload_cases_to_archive_item_without_interface(
             c.archives.iterate_all(params={"slug": "archive"})
         ).__anext__()
         item = await (
-            c.archive_items.iterate_all(params={"archive": archive["id"]})
+            c.archive_items.iterate_all(params={"archive": archive["pk"]})
         ).__anext__()
 
         with pytest.raises(ValueError) as e:
@@ -340,7 +340,7 @@ async def test_upload_cases_to_archive_item_with_existing_interface(
         archive = await (
             c.archives.iterate_all(params={"slug": "archive"})
         ).__anext__()
-        items = c.archive_items.iterate_all(params={"archive": archive["id"]})
+        items = c.archive_items.iterate_all(params={"archive": archive["pk"]})
         old_items_list = [item async for item in items]
 
         # create new archive item
@@ -351,7 +351,7 @@ async def test_upload_cases_to_archive_item_with_existing_interface(
         # retrieve existing archive item pk
         for _ in range(60):
             items = c.archive_items.iterate_all(
-                params={"archive": archive["id"]}
+                params={"archive": archive["pk"]}
             )
             items_list = [item async for item in items]
             if len(items_list) > len(old_items_list):
@@ -407,7 +407,7 @@ async def test_upload_cases_to_archive_item_with_new_interface(
         archive = await (
             c.archives.iterate_all(params={"slug": "archive"})
         ).__anext__()
-        items = c.archive_items.iterate_all(params={"archive": archive["id"]})
+        items = c.archive_items.iterate_all(params={"archive": archive["pk"]})
         old_items_list = [item async for item in items]
 
         # create new archive item
@@ -418,7 +418,7 @@ async def test_upload_cases_to_archive_item_with_new_interface(
         # retrieve existing archive item pk
         for _ in range(60):
             items = c.archive_items.iterate_all(
-                params={"archive": archive["id"]}
+                params={"archive": archive["pk"]}
             )
             items_list = [item async for item in items]
             if len(items_list) > len(old_items_list):
@@ -588,7 +588,7 @@ async def test_add_and_update_file_to_archive_item(local_grand_challenge):
         archive = await (
             c.archives.iterate_all(params={"slug": "archive"})
         ).__anext__()
-        items = c.archive_items.iterate_all(params={"archive": archive["id"]})
+        items = c.archive_items.iterate_all(params={"archive": archive["pk"]})
         old_items_list = [item async for item in items]
 
         # create new archive item
@@ -600,7 +600,7 @@ async def test_add_and_update_file_to_archive_item(local_grand_challenge):
         # retrieve existing archive item pk
         for _ in range(60):
             items = c.archive_items.iterate_all(
-                params={"archive": archive["id"]}
+                params={"archive": archive["pk"]}
             )
             items_list = [item async for item in items]
             if len(items_list) > len(old_items_list):
@@ -687,7 +687,7 @@ async def test_add_and_update_value_to_archive_item(local_grand_challenge):
         archive = await (
             c.archives.iterate_all(params={"slug": "archive"})
         ).__anext__()
-        items = c.archive_items.iterate_all(params={"archive": archive["id"]})
+        items = c.archive_items.iterate_all(params={"archive": archive["pk"]})
         old_items_list = [item async for item in items]
 
         # create new archive item
@@ -699,7 +699,7 @@ async def test_add_and_update_value_to_archive_item(local_grand_challenge):
         # retrieve existing archive item pk
         for _ in range(60):
             items = c.archive_items.iterate_all(
-                params={"archive": archive["id"]}
+                params={"archive": archive["pk"]}
             )
             items_list = [item async for item in items]
             if len(items_list) > len(old_items_list):
@@ -766,7 +766,7 @@ async def test_update_interface_kind_of_archive_item_image_civ(
         archive = await (
             c.archives.iterate_all(params={"slug": "archive"})
         ).__anext__()
-        items = c.archive_items.iterate_all(params={"archive": archive["id"]})
+        items = c.archive_items.iterate_all(params={"archive": archive["pk"]})
         old_items_list = [item async for item in items]
 
         # create new archive item
@@ -778,7 +778,7 @@ async def test_update_interface_kind_of_archive_item_image_civ(
         # retrieve existing archive item pk
         for _ in range(60):
             items = c.archive_items.iterate_all(
-                params={"archive": archive["id"]}
+                params={"archive": archive["pk"]}
             )
             items_list = [item async for item in items]
             if len(items_list) > len(old_items_list):
@@ -835,7 +835,7 @@ async def test_update_archive_item_with_non_existing_interface(
         archive = await (
             c.archives.iterate_all(params={"slug": "archive"})
         ).__anext__()
-        items = c.archive_items.iterate_all(params={"archive": archive["id"]})
+        items = c.archive_items.iterate_all(params={"archive": archive["pk"]})
         item_ids = [item["id"] async for item in items]
         with pytest.raises(ValueError) as e:
             _ = await c.update_archive_item(
@@ -854,7 +854,7 @@ async def test_update_archive_item_without_value(local_grand_challenge):
         archive = await (
             c.archives.iterate_all(params={"slug": "archive"})
         ).__anext__()
-        items = c.archive_items.iterate_all(params={"archive": archive["id"]})
+        items = c.archive_items.iterate_all(params={"archive": archive["pk"]})
         item_ids = [item["id"] async for item in items]
 
         with pytest.raises(ValueError) as e:

--- a/tests/async_integration_tests.py
+++ b/tests/async_integration_tests.py
@@ -479,7 +479,8 @@ async def test_create_job_with_upload(local_grand_challenge, files):
                     algorithm="test-algorithm-evaluation-1",
                     inputs={
                         "generic-medical-image": [
-                            Path(__file__).parent / "testdata" / f for f in files
+                            Path(__file__).parent / "testdata" / f
+                            for f in files
                         ]
                     },
                 )
@@ -512,14 +513,9 @@ async def test_create_job_with_upload(local_grand_challenge, files):
 @pytest.mark.anyio
 async def test_input_types_upload_cases(local_grand_challenge, files):
     async with AsyncClient(
-        base_url=local_grand_challenge,
-        verify=False,
-        token=ARCHIVE_TOKEN,
+        base_url=local_grand_challenge, verify=False, token=ARCHIVE_TOKEN
     ) as c:
-        await c.upload_cases(
-            archive="archive",
-            files=files,
-        )
+        await c.upload_cases(archive="archive", files=files)
 
 
 @pytest.mark.anyio
@@ -898,8 +894,7 @@ async def test_create_display_sets_from_images(local_grand_challenge):
         base_url=local_grand_challenge, verify=False, token=READERSTUDY_TOKEN
     ) as c:
         created = await c.create_display_sets_from_images(
-            reader_study="reader-study",
-            display_sets=display_sets,
+            reader_study="reader-study", display_sets=display_sets
         )
 
         assert len(created) == 2

--- a/tests/async_integration_tests.py
+++ b/tests/async_integration_tests.py
@@ -451,7 +451,7 @@ async def test_download_cases(local_grand_challenge, files, tmpdir):
                     filename=tmpdir / "image", url=us["image_set"][0]
                 )
                 break
-            except HTTPStatusError as ex:
+            except HTTPStatusError:
                 sleep(0.5)
         else:
             raise TimeoutError

--- a/tests/async_integration_tests.py
+++ b/tests/async_integration_tests.py
@@ -1,19 +1,40 @@
-import re
 from io import BytesIO
 from pathlib import Path
-from time import sleep
 
 import pytest
 from httpx import HTTPStatusError
 
 from gcapi import AsyncClient
 from gcapi.exceptions import MultipleObjectsReturned, ObjectNotFound
+from tests.utils import async_recurse_call
 
 RETINA_TOKEN = "f1f98a1733c05b12118785ffd995c250fe4d90da"
 ADMIN_TOKEN = "1b9436200001f2eaf57cd77db075cbb60a49a00a"
 READERSTUDY_TOKEN = "01614a77b1c0b4ecd402be50a8ff96188d5b011d"
 DEMO_PARTICIPANT_TOKEN = "00aa710f4dc5621a0cb64b0795fbba02e39d7700"
 ARCHIVE_TOKEN = "0d284528953157759d26c469297afcf6fd367f71"
+
+
+@async_recurse_call
+async def get_upload_session(client, upload_pk):
+    upl = await client.raw_image_upload_sessions.detail(upload_pk)
+    if upl["status"] != "Succeeded":
+        raise ValueError
+    return upl
+
+
+@async_recurse_call
+async def get_image(client, image_url):
+    return await client(url=image_url)
+
+
+@async_recurse_call
+async def get_archive_items(client, archive_pk, min_size):
+    i = client.archive_items.iterate_all(params={"archive": archive_pk})
+    il = [item async for item in i]
+    if len(il) <= min_size:
+        raise ValueError
+    return il
 
 
 @pytest.mark.parametrize(
@@ -207,25 +228,11 @@ async def test_upload_cases_to_archive(
             files=[Path(__file__).parent / "testdata" / f for f in files],
         )
 
-        for _ in range(60):
-            us = await c.raw_image_upload_sessions.detail(us["pk"])
-            if us["status"] == "Succeeded":
-                break
-            else:
-                sleep(0.5)
-        else:
-            raise TimeoutError
+        us = await get_upload_session(c, us["pk"])
 
         # Check that only one image was created
         assert len(us["image_set"]) == 1
-        for _ in range(60):
-            try:
-                image = await c(url=us["image_set"][0])
-                break
-            except HTTPStatusError:
-                sleep(0.5)
-        else:
-            raise TimeoutError
+        image = await get_image(c, us["image_set"][0])
 
         # And that it was added to the archive
         archive = await (
@@ -297,6 +304,7 @@ async def test_upload_cases_to_archive_item_with_existing_interface(
     async with AsyncClient(
         base_url=local_grand_challenge, verify=False, token=ARCHIVE_TOKEN
     ) as c:
+
         # retrieve existing archive item pk
         archive = await (
             c.archives.iterate_all(params={"slug": "archive"})
@@ -309,17 +317,11 @@ async def test_upload_cases_to_archive_item_with_existing_interface(
             archive="archive",
             files=[Path(__file__).parent / "testdata" / "image10x10x101.mha"],
         )
+
         # retrieve existing archive item pk
-        for _ in range(60):
-            items = c.archive_items.iterate_all(
-                params={"archive": archive["pk"]}
-            )
-            items_list = [item async for item in items]
-            if len(items_list) > len(old_items_list):
-                # item has been added
-                break
-            else:
-                sleep(0.5)
+        items_list = await get_archive_items(
+            c, archive["pk"], len(old_items_list)
+        )
 
         us = await c.upload_cases(
             archive_item=items_list[-1]["pk"],
@@ -327,25 +329,11 @@ async def test_upload_cases_to_archive_item_with_existing_interface(
             files=[Path(__file__).parent / "testdata" / "image10x10x101.mha"],
         )
 
-        for _ in range(60):
-            us = await c.raw_image_upload_sessions.detail(us["pk"])
-            if us["status"] == "Succeeded":
-                break
-            else:
-                sleep(0.5)
-        else:
-            raise TimeoutError
+        us = await get_upload_session(c, us["pk"])
 
         # Check that only one image was created
         assert len(us["image_set"]) == 1
-        for _ in range(60):
-            try:
-                image = await c(url=us["image_set"][0])
-                break
-            except HTTPStatusError:
-                sleep(0.5)
-        else:
-            raise TimeoutError
+        image = await get_image(c, us["image_set"][0])
 
         # And that it was added to the archive item
         item = await c.archive_items.detail(pk=items_list[-1]["pk"])
@@ -364,6 +352,7 @@ async def test_upload_cases_to_archive_item_with_new_interface(
     async with AsyncClient(
         base_url=local_grand_challenge, verify=False, token=ARCHIVE_TOKEN
     ) as c:
+
         archive = await (
             c.archives.iterate_all(params={"slug": "archive"})
         ).__anext__()
@@ -375,17 +364,10 @@ async def test_upload_cases_to_archive_item_with_new_interface(
             archive="archive",
             files=[Path(__file__).parent / "testdata" / "image10x10x101.mha"],
         )
-        # retrieve existing archive item pk
-        for _ in range(60):
-            items = c.archive_items.iterate_all(
-                params={"archive": archive["pk"]}
-            )
-            items_list = [item async for item in items]
-            if len(items_list) > len(old_items_list):
-                # item has been added
-                break
-            else:
-                sleep(0.5)
+
+        items_list = await get_archive_items(
+            c, archive["pk"], len(old_items_list)
+        )
 
         us = await c.upload_cases(
             archive_item=items_list[-1]["pk"],
@@ -393,25 +375,11 @@ async def test_upload_cases_to_archive_item_with_new_interface(
             files=[Path(__file__).parent / "testdata" / "image10x10x101.mha"],
         )
 
-        for _ in range(60):
-            us = await c.raw_image_upload_sessions.detail(us["pk"])
-            if us["status"] == "Succeeded":
-                break
-            else:
-                sleep(0.5)
-        else:
-            raise TimeoutError
+        us = await get_upload_session(c, us["pk"])
 
         # Check that only one image was created
         assert len(us["image_set"]) == 1
-        for _ in range(60):
-            try:
-                image = await c(url=us["image_set"][0])
-                break
-            except HTTPStatusError:
-                sleep(0.5)
-        else:
-            raise TimeoutError
+        image = await get_image(c, us["image_set"][0])
 
         # And that it was added to the archive item
         item = await c.archive_items.detail(pk=items_list[-1]["pk"])
@@ -434,27 +402,18 @@ async def test_download_cases(local_grand_challenge, files, tmpdir):
             files=[Path(__file__).parent / "testdata" / f for f in files],
         )
 
-        for _ in range(60):
-            us = await c.raw_image_upload_sessions.detail(us["pk"])
-            if us["status"] == "Succeeded":
-                break
-            else:
-                sleep(0.5)
-        else:
-            raise TimeoutError
+        us = await get_upload_session(c, us["pk"])
 
         # Check that we can download the uploaded image
         tmpdir = Path(tmpdir)
-        for _ in range(60):
-            try:
-                downloaded_files = await c.images.download(
-                    filename=tmpdir / "image", url=us["image_set"][0]
-                )
-                break
-            except HTTPStatusError:
-                sleep(0.5)
-        else:
-            raise TimeoutError
+
+        @async_recurse_call
+        async def get_download():
+            return await c.images.download(
+                filename=tmpdir / "image", url=us["image_set"][0]
+            )
+
+        downloaded_files = await get_download()
 
         assert len(downloaded_files) == 1
 
@@ -472,23 +431,20 @@ async def test_create_job_with_upload(local_grand_challenge, files):
         verify=False,
         token=DEMO_PARTICIPANT_TOKEN,
     ) as c:
+
+        @async_recurse_call
+        async def run_job():
+            return await c.run_external_job(
+                algorithm="test-algorithm-evaluation-1",
+                inputs={
+                    "generic-medical-image": [
+                        Path(__file__).parent / "testdata" / f for f in files
+                    ]
+                },
+            )
+
         # algorithm might not be ready yet
-        for _ in range(60):
-            try:
-                job = await c.run_external_job(
-                    algorithm="test-algorithm-evaluation-1",
-                    inputs={
-                        "generic-medical-image": [
-                            Path(__file__).parent / "testdata" / f
-                            for f in files
-                        ]
-                    },
-                )
-                break
-            except HTTPStatusError:
-                sleep(0.5)
-        else:
-            raise TimeoutError
+        job = await run_job()
 
         assert job["status"] == "Queued"
         assert len(job["inputs"]) == 1
@@ -597,16 +553,9 @@ async def test_add_and_update_file_to_archive_item(local_grand_challenge):
         )
 
         # retrieve existing archive item pk
-        for _ in range(60):
-            items = c.archive_items.iterate_all(
-                params={"archive": archive["pk"]}
-            )
-            items_list = [item async for item in items]
-            if len(items_list) > len(old_items_list):
-                # item has been added
-                break
-            else:
-                sleep(0.5)
+        items_list = await get_archive_items(
+            c, archive["pk"], len(old_items_list)
+        )
 
         old_civ_count = len(items_list[-1]["values"])
 
@@ -634,15 +583,15 @@ async def test_add_and_update_file_to_archive_item(local_grand_challenge):
             },
         )
 
-        for _ in range(60):
-            item_updated = await c.archive_items.detail(items_list[-1]["pk"])
-            if len(item_updated["values"]) == old_civ_count + 1:
-                # csv interface value has been added to item
-                break
-            else:
-                sleep(0.5)
-        else:
-            raise TimeoutError
+        @async_recurse_call
+        async def get_archive_detail():
+            item = await c.archive_items.detail(items_list[-1]["pk"])
+            if len(item["values"]) != old_civ_count + 1:
+                # csv interface value has not been added to item yet
+                raise ValueError
+            return item
+
+        item_updated = await get_archive_detail()
 
         csv_civ = item_updated["values"][-1]
         assert csv_civ["interface"]["slug"] == "predictions-csv-file"
@@ -659,18 +608,15 @@ async def test_add_and_update_file_to_archive_item(local_grand_challenge):
             },
         )
 
-        for _ in range(60):
-            item_updated_again = await c.archive_items.detail(
-                items_list[-1]["pk"]
-            )
-            if csv_civ not in item_updated_again["values"]:
-                # csv interface value has been added to item and the
-                # previously added pdf civ is no longer attached to this archive item
-                break
-            else:
-                sleep(0.5)
-        else:
-            raise TimeoutError
+        @async_recurse_call
+        async def get_updated_again_archive_item():
+            item = await c.archive_items.detail(items_list[-1]["pk"])
+            if csv_civ in item["values"]:
+                # csv interface value has been added to item
+                raise ValueError
+            return item
+
+        item_updated_again = await get_updated_again_archive_item()
 
         assert len(item_updated_again["values"]) == updated_civ_count
         new_csv_civ = item_updated_again["values"][-1]
@@ -696,17 +642,9 @@ async def test_add_and_update_value_to_archive_item(local_grand_challenge):
         )
 
         # retrieve existing archive item pk
-        for _ in range(60):
-            items = c.archive_items.iterate_all(
-                params={"archive": archive["pk"]}
-            )
-            items_list = [item async for item in items]
-            if len(items_list) > len(old_items_list):
-                # item has been added
-                break
-            else:
-                sleep(0.5)
-
+        items_list = await get_archive_items(
+            c, archive["pk"], len(old_items_list)
+        )
         old_civ_count = len(items_list[-1]["values"])
 
         _ = await c.update_archive_item(
@@ -714,15 +652,15 @@ async def test_add_and_update_value_to_archive_item(local_grand_challenge):
             values={"results-json-file": {"foo": 0.5}},
         )
 
-        for _ in range(60):
-            item_updated = await c.archive_items.detail(items_list[-1]["pk"])
-            if len(item_updated["values"]) == old_civ_count + 1:
-                # results json interface value has been added to the item
-                break
-            else:
-                sleep(0.5)
-        else:
-            raise TimeoutError
+        @async_recurse_call
+        async def get_archive_detail():
+            item = await c.archive_items.detail(items_list[-1]["pk"])
+            if len(item["values"]) != old_civ_count + 1:
+                # csv interface value has been added to item
+                raise ValueError
+            return item
+
+        item_updated = await get_archive_detail()
 
         json_civ = item_updated["values"][-1]
         assert json_civ["interface"]["slug"] == "results-json-file"
@@ -734,19 +672,17 @@ async def test_add_and_update_value_to_archive_item(local_grand_challenge):
             values={"results-json-file": {"foo": 0.8}},
         )
 
-        for _ in range(60):
-            item_updated_again = await c.archive_items.detail(
-                items_list[-1]["pk"]
-            )
-            if json_civ not in item_updated_again["values"]:
+        @async_recurse_call
+        async def get_updated_archive_detail():
+            item = await c.archive_items.detail(items_list[-1]["pk"])
+            if json_civ in item["values"]:
                 # results json interface value has been added to the item and
                 # the previously added json civ is no longer attached
                 # to this archive item
-                break
-            else:
-                sleep(0.5)
-        else:
-            raise TimeoutError
+                raise ValueError
+            return item
+
+        item_updated_again = await get_updated_archive_detail()
 
         assert len(item_updated_again["values"]) == updated_civ_count
         new_json_civ = item_updated_again["values"][-1]
@@ -775,16 +711,9 @@ async def test_update_interface_kind_of_archive_item_image_civ(
         )
 
         # retrieve existing archive item pk
-        for _ in range(60):
-            items = c.archive_items.iterate_all(
-                params={"archive": archive["pk"]}
-            )
-            items_list = [item async for item in items]
-            if len(items_list) > len(old_items_list):
-                # item has been added
-                break
-            else:
-                sleep(0.5)
+        items_list = await get_archive_items(
+            c, archive["pk"], len(old_items_list)
+        )
 
         old_civ_count = len(items_list[-1]["values"])
 
@@ -793,7 +722,7 @@ async def test_update_interface_kind_of_archive_item_image_civ(
             == "generic-medical-image"
         )
         im = items_list[-1]["values"][0]["image"]
-        image = await c(url=im)
+        image = await get_image(c, im)
 
         # change interface slug from generic-medical-image to generic-overlay
         _ = await c.update_archive_item(
@@ -801,18 +730,15 @@ async def test_update_interface_kind_of_archive_item_image_civ(
             values={"generic-overlay": image["api_url"]},
         )
 
-        for _ in range(60):
-            item_updated = await c.archive_items.detail(items_list[-1]["pk"])
-            if (
-                item_updated["values"][-1]["interface"]["slug"]
-                == "generic-overlay"
-            ):
-                # interface type has been replaced
-                break
-            else:
-                sleep(0.5)
-        else:
-            raise TimeoutError
+        @async_recurse_call
+        async def get_updated_archive_detail():
+            item = await c.archive_items.detail(items_list[-1]["pk"])
+            if item["values"][-1]["interface"]["slug"] != "generic-overlay":
+                # interface type has not yet been replaced
+                raise ValueError
+            return item
+
+        item_updated = await get_updated_archive_detail()
 
         # still the same amount of civs
         assert len(item_updated["values"]) == old_civ_count
@@ -868,15 +794,6 @@ async def test_update_archive_item_without_value(local_grand_challenge):
 
 @pytest.mark.anyio
 async def test_create_display_sets_from_images(local_grand_challenge):
-    def parse_uuid(gcurl):
-        match = re.match(
-            ".*/?(?P<uuid>[^/]*[a-f0-9]{8}-?[a-f0-9]{4}-?[a-f0-9]{4}-?[a-f0-9]{4}-?[a-f0-9]{12})/?",
-            gcurl,
-        )
-        if not match:
-            raise ValueError("Could not find uuid")
-        return match.group("uuid")
-
     display_sets = [
         {
             "generic-medical-image": [
@@ -909,15 +826,12 @@ async def test_create_display_sets_from_images(local_grand_challenge):
         assert all([x in ds_pks for x in created])
 
         # Check that the files are added to the display set
+        @async_recurse_call
         async def check_file(ds_pk):
-            for _ in range(60):
-                ds = await c.reader_studies.display_sets.detail(pk=ds_pk)
-                if len(ds["values"]) > 0:
-                    break
-                else:
-                    sleep(0.5)
-            else:
-                raise TimeoutError
+            ds = await c.reader_studies.display_sets.detail(pk=ds_pk)
+            if len(ds["values"]) <= 0:
+                raise ValueError
+            return ds
 
         for pk in created:
             await check_file(pk)

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -386,18 +386,16 @@ def test_download_cases(local_grand_challenge, files, tmpdir):
 
     # Check that we can download the uploaded image
     tmpdir = Path(tmpdir)
-    error = None
-    for _ in range(10):
+    for _ in range(60):
         try:
             downloaded_files = c.images.download(
                 filename=tmpdir / "image", url=us["image_set"][0]
             )
             break
-        except HTTPStatusError as ex:
-            error = ex
-            sleep(0.1)
+        except HTTPStatusError:
+            sleep(0.5)
     else:
-        raise error
+        raise TimeoutError
 
     assert len(downloaded_files) == 1
 

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -238,10 +238,10 @@ def test_upload_cases_to_archive(local_grand_challenge, files, interface):
 
     # And that it was added to the archive
     archive = next(c.archives.iterate_all(params={"slug": "archive"}))
-    archive_images = c.images.iterate_all(params={"archive": archive["id"]})
+    archive_images = c.images.iterate_all(params={"archive": archive["pk"]})
     assert image["pk"] in [im["pk"] for im in archive_images]
     archive_items = c.archive_items.iterate_all(
-        params={"archive": archive["id"]}
+        params={"archive": archive["pk"]}
     )
     # with the correct interface
     image_pk_to_interface_slug_dict = {
@@ -269,7 +269,7 @@ def test_upload_cases_to_archive_item_without_interface(local_grand_challenge):
     )
     # retrieve existing archive item pk
     archive = next(c.archives.iterate_all(params={"slug": "archive"}))
-    item = next(c.archive_items.iterate_all(params={"archive": archive["id"]}))
+    item = next(c.archive_items.iterate_all(params={"archive": archive["pk"]}))
 
     # try upload without providing interface
     with pytest.raises(ValueError) as e:
@@ -288,7 +288,7 @@ def test_upload_cases_to_archive_item_with_existing_interface(
     )
     # retrieve existing archive item pk
     archive = next(c.archives.iterate_all(params={"slug": "archive"}))
-    item = next(c.archive_items.iterate_all(params={"archive": archive["id"]}))
+    item = next(c.archive_items.iterate_all(params={"archive": archive["pk"]}))
 
     us = c.upload_cases(
         archive_item=item["id"],
@@ -336,7 +336,7 @@ def test_upload_cases_to_archive_item_with_new_interface(
     )
     # retrieve existing archive item pk
     archive = next(c.archives.iterate_all(params={"slug": "archive"}))
-    item = next(c.archive_items.iterate_all(params={"archive": archive["id"]}))
+    item = next(c.archive_items.iterate_all(params={"archive": archive["pk"]}))
 
     us = c.upload_cases(
         archive_item=item["id"],
@@ -492,7 +492,7 @@ def test_add_and_update_file_to_archive_item(local_grand_challenge):
     # check number of archive items
     archive = next(c.archives.iterate_all(params={"slug": "archive"}))
     old_items_list = list(
-        c.archive_items.iterate_all(params={"archive": archive["id"]})
+        c.archive_items.iterate_all(params={"archive": archive["pk"]})
     )
 
     # create new archive item
@@ -504,7 +504,7 @@ def test_add_and_update_file_to_archive_item(local_grand_challenge):
     # retrieve existing archive item pk
     for _ in range(60):
         items = list(
-            c.archive_items.iterate_all(params={"archive": archive["id"]})
+            c.archive_items.iterate_all(params={"archive": archive["pk"]})
         )
         if len(items) > len(old_items_list):
             # item has been added
@@ -586,7 +586,7 @@ def test_add_and_update_value_to_archive_item(local_grand_challenge):
     # check number of archive items
     archive = next(c.archives.iterate_all(params={"slug": "archive"}))
     old_items_list = list(
-        c.archive_items.iterate_all(params={"archive": archive["id"]})
+        c.archive_items.iterate_all(params={"archive": archive["pk"]})
     )
 
     # create new archive item
@@ -598,7 +598,7 @@ def test_add_and_update_value_to_archive_item(local_grand_challenge):
     # retrieve existing archive item pk
     for _ in range(60):
         items = list(
-            c.archive_items.iterate_all(params={"archive": archive["id"]})
+            c.archive_items.iterate_all(params={"archive": archive["pk"]})
         )
         if len(items) > len(old_items_list):
             # item has been added
@@ -660,7 +660,7 @@ def test_update_interface_kind_of_archive_item_image_civ(
     # check number of archive items
     archive = next(c.archives.iterate_all(params={"slug": "archive"}))
     old_items_list = list(
-        c.archive_items.iterate_all(params={"archive": archive["id"]})
+        c.archive_items.iterate_all(params={"archive": archive["pk"]})
     )
 
     # create new archive item
@@ -672,7 +672,7 @@ def test_update_interface_kind_of_archive_item_image_civ(
     # retrieve existing archive item pk
     for _ in range(60):
         items = list(
-            c.archive_items.iterate_all(params={"archive": archive["id"]})
+            c.archive_items.iterate_all(params={"archive": archive["pk"]})
         )
         if len(items) > len(old_items_list):
             # item has been added
@@ -725,7 +725,7 @@ def test_update_archive_item_with_non_existing_interface(
     # retrieve existing archive item pk
     archive = next(c.archives.iterate_all(params={"slug": "archive"}))
     items = list(
-        c.archive_items.iterate_all(params={"archive": archive["id"]})
+        c.archive_items.iterate_all(params={"archive": archive["pk"]})
     )
     with pytest.raises(ValueError) as e:
         _ = c.update_archive_item(
@@ -742,7 +742,7 @@ def test_update_archive_item_without_value(local_grand_challenge):
     # retrieve existing archive item pk
     archive = next(c.archives.iterate_all(params={"slug": "archive"}))
     items = list(
-        c.archive_items.iterate_all(params={"archive": archive["id"]})
+        c.archive_items.iterate_all(params={"archive": archive["pk"]})
     )
 
     with pytest.raises(ValueError) as e:

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -120,10 +120,10 @@ def test_create_single_polygon_annotations(local_grand_challenge):
 )
 def test_input_types_upload_cases(local_grand_challenge, files):
     c = Client(
-        base_url=local_grand_challenge, verify=False, token=READERSTUDY_TOKEN
+        base_url=local_grand_challenge, verify=False, token=ARCHIVE_TOKEN
     )
     c.upload_cases(
-        reader_study="reader-study",
+        archive="archive",
         files=files,
     )
 
@@ -367,11 +367,11 @@ def test_upload_cases_to_archive_item_with_new_interface(
 @pytest.mark.parametrize("files", (["image10x10x101.mha"],))
 def test_download_cases(local_grand_challenge, files, tmpdir):
     c = Client(
-        base_url=local_grand_challenge, verify=False, token=READERSTUDY_TOKEN
+        base_url=local_grand_challenge, verify=False, token=ARCHIVE_TOKEN
     )
 
     us = c.upload_cases(
-        reader_study="reader-study",
+        archive="archive",
         files=[Path(__file__).parent / "testdata" / f for f in files],
     )
 
@@ -383,7 +383,8 @@ def test_download_cases(local_grand_challenge, files, tmpdir):
             sleep(0.5)
     else:
         raise TimeoutError
-
+    # give some time to make sure permissions are set
+    sleep(0.5)
     # Check that we can download the uploaded image
     tmpdir = Path(tmpdir)
     downloaded_files = c.images.download(

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -413,14 +413,23 @@ def test_create_job_with_upload(local_grand_challenge, files):
         token=DEMO_PARTICIPANT_TOKEN,
     )
 
-    job = c.run_external_job(
-        algorithm="test-algorithm-evaluation-1",
-        inputs={
-            "generic-medical-image": [
-                Path(__file__).parent / "testdata" / f for f in files
-            ]
-        },
-    )
+    # algorithm might not be ready yet
+    for _ in range(60):
+        try:
+            job = c.run_external_job(
+                algorithm="test-algorithm-evaluation-1",
+                inputs={
+                    "generic-medical-image": [
+                        Path(__file__).parent / "testdata" / f for f in files
+                    ]
+                },
+            )
+            break
+        except HTTPStatusError:
+            sleep(0.5)
+    else:
+        raise TimeoutError
+
     assert job["status"] == "Queued"
     assert len(job["inputs"]) == 1
     job = c.algorithm_jobs.detail(job["pk"])

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -122,10 +122,7 @@ def test_input_types_upload_cases(local_grand_challenge, files):
     c = Client(
         base_url=local_grand_challenge, verify=False, token=ARCHIVE_TOKEN
     )
-    c.upload_cases(
-        archive="archive",
-        files=files,
-    )
+    c.upload_cases(archive="archive", files=files)
 
 
 def test_raw_image_and_upload_session(local_grand_challenge):
@@ -786,8 +783,7 @@ def test_create_display_sets_from_images(local_grand_challenge):
     ]
 
     created = c.create_display_sets_from_images(
-        reader_study="reader-study",
-        display_sets=display_sets,
+        reader_study="reader-study", display_sets=display_sets
     )
 
     assert len(created) == 2

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -383,13 +383,22 @@ def test_download_cases(local_grand_challenge, files, tmpdir):
             sleep(0.5)
     else:
         raise TimeoutError
-    # give some time to make sure permissions are set
-    sleep(0.5)
+
     # Check that we can download the uploaded image
     tmpdir = Path(tmpdir)
-    downloaded_files = c.images.download(
-        filename=tmpdir / "image", url=us["image_set"][0]
-    )
+    error = None
+    for _ in range(10):
+        try:
+            downloaded_files = c.images.download(
+                filename=tmpdir / "image", url=us["image_set"][0]
+            )
+            break
+        except HTTPStatusError as ex:
+            error = ex
+            sleep(0.1)
+    else:
+        raise error
+
     assert len(downloaded_files) == 1
 
     # Check that the downloaded file is a mha file

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -1,19 +1,41 @@
-import re
 from io import BytesIO
 from pathlib import Path
-from time import sleep
 
 import pytest
 from httpx import HTTPStatusError
 
 from gcapi import Client
 from gcapi.exceptions import MultipleObjectsReturned, ObjectNotFound
+from tests.utils import recurse_call
 
 RETINA_TOKEN = "f1f98a1733c05b12118785ffd995c250fe4d90da"
 ADMIN_TOKEN = "1b9436200001f2eaf57cd77db075cbb60a49a00a"
 READERSTUDY_TOKEN = "01614a77b1c0b4ecd402be50a8ff96188d5b011d"
 DEMO_PARTICIPANT_TOKEN = "00aa710f4dc5621a0cb64b0795fbba02e39d7700"
 ARCHIVE_TOKEN = "0d284528953157759d26c469297afcf6fd367f71"
+
+
+@recurse_call
+def get_upload_session(client, upload_pk):
+    upl = client.raw_image_upload_sessions.detail(upload_pk)
+    if upl["status"] != "Succeeded":
+        raise ValueError
+    return upl
+
+
+@recurse_call
+def get_image(client, image_url):
+    return client(url=image_url)
+
+
+@recurse_call
+def get_archive_items(client, archive_pk, min_size):
+    items = list(
+        client.archive_items.iterate_all(params={"archive": archive_pk})
+    )
+    if len(items) <= min_size:
+        raise ValueError
+    return items
 
 
 @pytest.mark.parametrize(
@@ -189,25 +211,12 @@ def test_upload_cases_to_archive(local_grand_challenge, files, interface):
         files=[Path(__file__).parent / "testdata" / f for f in files],
     )
 
-    for _ in range(60):
-        us = c.raw_image_upload_sessions.detail(us["pk"])
-        if us["status"] == "Succeeded":
-            break
-        else:
-            sleep(0.5)
-    else:
-        raise TimeoutError
+    us = get_upload_session(c, us["pk"])
 
     # Check that only one image was created
     assert len(us["image_set"]) == 1
-    for _ in range(60):
-        try:
-            image = c(url=us["image_set"][0])
-            break
-        except HTTPStatusError:
-            sleep(0.5)
-    else:
-        raise TimeoutError
+
+    image = get_image(c, us["image_set"][0])
 
     # And that it was added to the archive
     archive = next(c.archives.iterate_all(params={"slug": "archive"}))
@@ -281,25 +290,12 @@ def test_upload_cases_to_archive_item_with_existing_interface(
         files=[Path(__file__).parent / "testdata" / "image10x10x101.mha"],
     )
 
-    for _ in range(60):
-        us = c.raw_image_upload_sessions.detail(us["pk"])
-        if us["status"] == "Succeeded":
-            break
-        else:
-            sleep(0.5)
-    else:
-        raise TimeoutError
+    us = get_upload_session(c, us["pk"])
 
     # Check that only one image was created
     assert len(us["image_set"]) == 1
-    for _ in range(60):
-        try:
-            image = c(url=us["image_set"][0])
-            break
-        except HTTPStatusError:
-            sleep(0.5)
-    else:
-        raise TimeoutError
+
+    image = get_image(c, us["image_set"][0])
 
     # And that it was added to the archive item
     item = c.archive_items.detail(pk=item["pk"])
@@ -329,25 +325,11 @@ def test_upload_cases_to_archive_item_with_new_interface(
         files=[Path(__file__).parent / "testdata" / "image10x10x101.mha"],
     )
 
-    for _ in range(60):
-        us = c.raw_image_upload_sessions.detail(us["pk"])
-        if us["status"] == "Succeeded":
-            break
-        else:
-            sleep(0.5)
-    else:
-        raise TimeoutError
-
+    us = get_upload_session(c, us["pk"])
     # Check that only one image was created
     assert len(us["image_set"]) == 1
-    for _ in range(60):
-        try:
-            image = c(url=us["image_set"][0])
-            break
-        except HTTPStatusError:
-            sleep(0.5)
-    else:
-        raise TimeoutError
+
+    image = get_image(c, us["image_set"][0])
 
     # And that it was added to the archive item
     item = c.archive_items.detail(pk=item["pk"])
@@ -372,27 +354,18 @@ def test_download_cases(local_grand_challenge, files, tmpdir):
         files=[Path(__file__).parent / "testdata" / f for f in files],
     )
 
-    for _ in range(60):
-        us = c.raw_image_upload_sessions.detail(us["pk"])
-        if us["status"] == "Succeeded":
-            break
-        else:
-            sleep(0.5)
-    else:
-        raise TimeoutError
+    us = get_upload_session(c, us["pk"])
 
     # Check that we can download the uploaded image
     tmpdir = Path(tmpdir)
-    for _ in range(60):
-        try:
-            downloaded_files = c.images.download(
-                filename=tmpdir / "image", url=us["image_set"][0]
-            )
-            break
-        except HTTPStatusError:
-            sleep(0.5)
-    else:
-        raise TimeoutError
+
+    @recurse_call
+    def get_download():
+        return c.images.download(
+            filename=tmpdir / "image", url=us["image_set"][0]
+        )
+
+    downloaded_files = get_download()
 
     assert len(downloaded_files) == 1
 
@@ -410,22 +383,19 @@ def test_create_job_with_upload(local_grand_challenge, files):
         token=DEMO_PARTICIPANT_TOKEN,
     )
 
+    @recurse_call
+    def run_job():
+        return c.run_external_job(
+            algorithm="test-algorithm-evaluation-1",
+            inputs={
+                "generic-medical-image": [
+                    Path(__file__).parent / "testdata" / f for f in files
+                ]
+            },
+        )
+
     # algorithm might not be ready yet
-    for _ in range(60):
-        try:
-            job = c.run_external_job(
-                algorithm="test-algorithm-evaluation-1",
-                inputs={
-                    "generic-medical-image": [
-                        Path(__file__).parent / "testdata" / f for f in files
-                    ]
-                },
-            )
-            break
-        except HTTPStatusError:
-            sleep(0.5)
-    else:
-        raise TimeoutError
+    job = run_job()
 
     assert job["status"] == "Queued"
     assert len(job["inputs"]) == 1
@@ -504,15 +474,7 @@ def test_add_and_update_file_to_archive_item(local_grand_challenge):
     )
 
     # retrieve existing archive item pk
-    for _ in range(60):
-        items = list(
-            c.archive_items.iterate_all(params={"archive": archive["pk"]})
-        )
-        if len(items) > len(old_items_list):
-            # item has been added
-            break
-        else:
-            sleep(0.5)
+    items = get_archive_items(c, archive["pk"], len(old_items_list))
 
     old_civ_count = len(items[-1]["values"])
 
@@ -540,15 +502,15 @@ def test_add_and_update_file_to_archive_item(local_grand_challenge):
         },
     )
 
-    for _ in range(60):
-        item_updated = c.archive_items.detail(items[-1]["pk"])
-        if len(item_updated["values"]) == old_civ_count + 1:
-            # csv interface value has been added to item
-            break
-        else:
-            sleep(0.5)
-    else:
-        raise TimeoutError
+    @recurse_call
+    def get_updated_archive_item():
+        archive_item = c.archive_items.detail(items[-1]["pk"])
+        if len(archive_item["values"]) != old_civ_count + 1:
+            # item has not been added
+            raise ValueError
+        return archive_item
+
+    item_updated = get_updated_archive_item()
 
     csv_civ = item_updated["values"][-1]
     assert csv_civ["interface"]["slug"] == "predictions-csv-file"
@@ -565,16 +527,15 @@ def test_add_and_update_file_to_archive_item(local_grand_challenge):
         },
     )
 
-    for _ in range(60):
-        item_updated_again = c.archive_items.detail(items[-1]["pk"])
-        if csv_civ not in item_updated_again["values"]:
-            # csv interface value has been added to item and the
-            # previously added pdf civ is no longer attached to this archive item
-            break
-        else:
-            sleep(0.5)
-    else:
-        raise TimeoutError
+    @recurse_call
+    def get_updated_again_archive_item():
+        archive_item = c.archive_items.detail(items[-1]["pk"])
+        if csv_civ in archive_item["values"]:
+            # item has not been added
+            raise ValueError
+        return archive_item
+
+    item_updated_again = get_updated_again_archive_item()
 
     assert len(item_updated_again["values"]) == updated_civ_count
     new_csv_civ = item_updated_again["values"][-1]
@@ -598,16 +559,7 @@ def test_add_and_update_value_to_archive_item(local_grand_challenge):
     )
 
     # retrieve existing archive item pk
-    for _ in range(60):
-        items = list(
-            c.archive_items.iterate_all(params={"archive": archive["pk"]})
-        )
-        if len(items) > len(old_items_list):
-            # item has been added
-            break
-        else:
-            sleep(0.5)
-
+    items = get_archive_items(c, archive["pk"], len(old_items_list))
     old_civ_count = len(items[-1]["values"])
 
     _ = c.update_archive_item(
@@ -615,15 +567,15 @@ def test_add_and_update_value_to_archive_item(local_grand_challenge):
         values={"results-json-file": {"foo": 0.5}},
     )
 
-    for _ in range(60):
-        item_updated = c.archive_items.detail(items[-1]["pk"])
-        if len(item_updated["values"]) == old_civ_count + 1:
-            # results json interface value has been added to the item
-            break
-        else:
-            sleep(0.5)
-    else:
-        raise TimeoutError
+    @recurse_call
+    def get_archive_item_detail():
+        i = c.archive_items.detail(items[-1]["pk"])
+        if len(i["values"]) != old_civ_count + 1:
+            # item has been added
+            raise ValueError
+        return i
+
+    item_updated = get_archive_item_detail()
 
     json_civ = item_updated["values"][-1]
     assert json_civ["interface"]["slug"] == "results-json-file"
@@ -635,17 +587,15 @@ def test_add_and_update_value_to_archive_item(local_grand_challenge):
         values={"results-json-file": {"foo": 0.8}},
     )
 
-    for _ in range(60):
-        item_updated_again = c.archive_items.detail(items[-1]["pk"])
-        if json_civ not in item_updated_again["values"]:
-            # results json interface value has been added to the item and
-            # the previously added json civ is no longer attached
-            # to this archive item
-            break
-        else:
-            sleep(0.5)
-    else:
-        raise TimeoutError
+    @recurse_call
+    def get_updated_archive_item_detail():
+        i = c.archive_items.detail(items[-1]["pk"])
+        if json_civ in i["values"]:
+            # item has not been added yet
+            raise ValueError
+        return i
+
+    item_updated_again = get_updated_archive_item_detail()
 
     assert len(item_updated_again["values"]) == updated_civ_count
     new_json_civ = item_updated_again["values"][-1]
@@ -672,23 +622,14 @@ def test_update_interface_kind_of_archive_item_image_civ(
     )
 
     # retrieve existing archive item pk
-    for _ in range(60):
-        items = list(
-            c.archive_items.iterate_all(params={"archive": archive["pk"]})
-        )
-        if len(items) > len(old_items_list):
-            # item has been added
-            break
-        else:
-            sleep(0.5)
-
+    items = get_archive_items(c, archive["pk"], len(old_items_list))
     old_civ_count = len(items[-1]["values"])
 
     assert (
         items[-1]["values"][0]["interface"]["slug"] == "generic-medical-image"
     )
     im = items[-1]["values"][0]["image"]
-    image = c(url=im)
+    image = get_image(c, im)
 
     # change interface slug from generic-medical-image to generic-overlay
     _ = c.update_archive_item(
@@ -696,18 +637,15 @@ def test_update_interface_kind_of_archive_item_image_civ(
         values={"generic-overlay": image["api_url"]},
     )
 
-    for _ in range(60):
-        item_updated = c.archive_items.detail(items[-1]["pk"])
-        if (
-            item_updated["values"][-1]["interface"]["slug"]
-            == "generic-overlay"
-        ):
-            # interface type has been replaced
-            break
-        else:
-            sleep(0.5)
-    else:
-        raise TimeoutError
+    @recurse_call
+    def get_updated_archive_items():
+        i = c.archive_items.detail(items[-1]["pk"])
+        if i["values"][-1]["interface"]["slug"] != "generic-overlay":
+            # item has not been added yet
+            raise ValueError
+        return i
+
+    item_updated = get_updated_archive_items()
 
     # still the same amount of civs
     assert len(item_updated["values"]) == old_civ_count
@@ -756,15 +694,6 @@ def test_update_archive_item_without_value(local_grand_challenge):
 
 
 def test_create_display_sets_from_images(local_grand_challenge):
-    def parse_uuid(gcurl):
-        match = re.match(
-            ".*/?(?P<uuid>[^/]*[a-f0-9]{8}-?[a-f0-9]{4}-?[a-f0-9]{4}-?[a-f0-9]{4}-?[a-f0-9]{12})/?",
-            gcurl,
-        )
-        if not match:
-            raise ValueError("Could not find uuid")
-        return match.group("uuid")
-
     c = Client(
         base_url=local_grand_challenge, verify=False, token=READERSTUDY_TOKEN
     )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,32 @@
+from httpx import HTTPStatusError
+from time import sleep
+
+
+def recurse_call(func):
+	def wrapper(*args, **kwargs):
+		for _ in range(60):
+			try:
+				result = func(*args, **kwargs)
+				break
+			except (HTTPStatusError, ValueError):
+				sleep(0.5)
+		else:
+			raise TimeoutError
+		return result
+
+	return wrapper
+
+
+def async_recurse_call(func):
+	async def wrapper(*args, **kwargs):
+		for _ in range(60):
+			try:
+				result = await func(*args, **kwargs)
+				break
+			except (HTTPStatusError, ValueError):
+				sleep(0.5)
+		else:
+			raise TimeoutError
+		return result
+
+	return wrapper

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,6 @@
-from httpx import HTTPStatusError
 from time import sleep
+
+from httpx import HTTPStatusError
 
 
 def recurse_call(func):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,30 +3,30 @@ from time import sleep
 
 
 def recurse_call(func):
-	def wrapper(*args, **kwargs):
-		for _ in range(60):
-			try:
-				result = func(*args, **kwargs)
-				break
-			except (HTTPStatusError, ValueError):
-				sleep(0.5)
-		else:
-			raise TimeoutError
-		return result
+    def wrapper(*args, **kwargs):
+        for _ in range(60):
+            try:
+                result = func(*args, **kwargs)
+                break
+            except (HTTPStatusError, ValueError):
+                sleep(0.5)
+        else:
+            raise TimeoutError
+        return result
 
-	return wrapper
+    return wrapper
 
 
 def async_recurse_call(func):
-	async def wrapper(*args, **kwargs):
-		for _ in range(60):
-			try:
-				result = await func(*args, **kwargs)
-				break
-			except (HTTPStatusError, ValueError):
-				sleep(0.5)
-		else:
-			raise TimeoutError
-		return result
+    async def wrapper(*args, **kwargs):
+        for _ in range(60):
+            try:
+                result = await func(*args, **kwargs)
+                break
+            except (HTTPStatusError, ValueError):
+                sleep(0.5)
+        else:
+            raise TimeoutError
+        return result
 
-	return wrapper
+    return wrapper


### PR DESCRIPTION
Removes the (now unsupported) option of using upload_cases for creating images for reader studies (replaced by create_display_sets_from_images).