### PR TITLE
Add automatic retries for requests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     hooks:
       - id: black
         language: python
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 4.0.1
     hooks:
       - id: flake8

--- a/gcapi/client.py
+++ b/gcapi/client.py
@@ -389,15 +389,22 @@ class ClientBase(ApiDefinitions, ClientInterface):
     def __init__(
         self,
         init_base_cls,
+        transport_cls,
         token: str = "",
         base_url: str = "https://grand-challenge.org/api/v1/",
         verify: bool = True,
         timeout: float = 60.0,
+        retries=None,
     ):
         init_base_cls.__init__(
-            self, verify=verify, timeout=Timeout(timeout=timeout)
+            self,
+            verify=verify,
+            timeout=Timeout(timeout=timeout),
+            transport=transport_cls(
+                verify=verify,
+                retries=retries,
+            ),
         )
-
         self.headers.update({"Accept": "application/json"})
         self._auth_header = _generate_auth_header(token=token)
 

--- a/gcapi/gcapi.py
+++ b/gcapi/gcapi.py
@@ -16,6 +16,7 @@ import httpx
 from .apibase import APIBase
 from .client import ClientBase
 from .sync_async_hybrid_support import CapturedCall, is_generator
+from .transports import RetryTransport, AsyncRetryTransport
 
 logger = logging.getLogger(__name__)
 
@@ -120,7 +121,9 @@ class Client(httpx.Client, WrapApiInterfaces, ClientBase):
         return result
 
     def __init__(self, *args, **kwargs):
-        ClientBase.__init__(self, httpx.Client, *args, **kwargs)
+        ClientBase.__init__(
+            self, httpx.Client, RetryTransport, *args, **kwargs
+        )
         self._wrap_client_base_interfaces()
 
     def __call__(self, *args, **kwargs):
@@ -172,7 +175,9 @@ class AsyncClient(httpx.AsyncClient, WrapApiInterfaces, ClientBase):
         return result
 
     def __init__(self, *args, **kwargs):
-        ClientBase.__init__(self, httpx.AsyncClient, *args, **kwargs)
+        ClientBase.__init__(
+            self, httpx.AsyncClient, AsyncRetryTransport, *args, **kwargs
+        )
         self._wrap_client_base_interfaces()
 
     async def __call__(self, *args, **kwargs):

--- a/gcapi/gcapi.py
+++ b/gcapi/gcapi.py
@@ -16,7 +16,7 @@ import httpx
 from .apibase import APIBase
 from .client import ClientBase
 from .sync_async_hybrid_support import CapturedCall, is_generator
-from .transports import RetryTransport, AsyncRetryTransport
+from .transports import AsyncRetryTransport, RetryTransport
 
 logger = logging.getLogger(__name__)
 

--- a/gcapi/retries.py
+++ b/gcapi/retries.py
@@ -1,0 +1,7 @@
+import abc
+
+
+class RetryStrategy(abc.ABC):
+    def get_interval_ms(self, response):
+        """Returns the number of ms to pause before the next retry given the latest response"""
+        pass

--- a/gcapi/retries.py
+++ b/gcapi/retries.py
@@ -1,11 +1,10 @@
-import abc
-
-
-class RetryStrategy(abc.ABC):
-    def get_interval(self, response):
+class BaseRetries:
+    def get_delay(self, latest_response):
         """
         Returns the number of seconds to pause before the next retry, based on the latest response.
 
         Optionally, if None is returned no retry is to be performed.
         """
-        pass
+        raise NotImplementedError(
+            "The 'get_delay' method must be implemented."
+        )

--- a/gcapi/retries.py
+++ b/gcapi/retries.py
@@ -2,6 +2,10 @@ import abc
 
 
 class RetryStrategy(abc.ABC):
-    def get_interval_ms(self, response):
-        """Returns the number of ms to pause before the next retry given the latest response"""
+    def get_interval(self, response):
+        """
+        Returns the number of seconds to pause before the next retry, based on the latest response.
+
+        Optionally, if None is returned no retry is to be performed.
+        """
         pass

--- a/gcapi/retries.py
+++ b/gcapi/retries.py
@@ -29,8 +29,7 @@ class SelectiveBackoffStrategy(BaseRetryStrategy):
     Retries responses with 403 and 404 once and several transient
     server errors (i.e. 5xx) with an exponential backoff.
 
-    Each response code has its own backoff counter
-
+    Each response code has its own backoff counter.
     """
 
     def __init__(self, backoff_factor, maximum_number_of_retries):

--- a/gcapi/retries.py
+++ b/gcapi/retries.py
@@ -1,4 +1,3 @@
-from functools import wraps
 from typing import Dict, Optional
 
 import httpx
@@ -42,7 +41,6 @@ class SelectiveBackoffStrategy(BaseRetryStrategy):
             maximum_number_of_retries=self.maximum_number_of_retries,
         )
 
-    @wraps(BaseRetryStrategy.get_delay)
     def get_delay(self, latest_response: httpx.Response) -> Optional[Seconds]:
         if latest_response.status_code in (
             codes.INTERNAL_SERVER_ERROR,

--- a/gcapi/transports.py
+++ b/gcapi/transports.py
@@ -1,63 +1,69 @@
 from time import sleep
 
 import anyio
-from httpx import HTTPTransport, AsyncHTTPTransport, HTTPStatusError
+from httpx import HTTPTransport, AsyncHTTPTransport
 
-from gcapi.retries import RetryStrategy
-
-
-def is_successful(response):
-    try:
-        response.raise_for_status()
-    except HTTPStatusError:
-        return False
-    else:
-        return True
+from gcapi.retries import BaseRetries
 
 
 class BaseRetryTransport:
     def __init__(self, retries, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if retries is not None and not issubclass(retries, RetryStrategy):
-            raise ValueError(
-                "Provided retries strategy should be None or an instance of RetryStrategy"
-            )
         self.retry_strategy_cls = retries
+
+        if self.retry_strategy_cls:
+            obj = self.retry_strategy_cls()
+            if not isinstance(obj, BaseRetries):
+                raise ValueError(
+                    "Provided retries strategy should be None or when called produce an instance of BaseRetry"
+                )
 
 
 class RetryTransport(BaseRetryTransport, HTTPTransport):
+    """
+    Transport that retries unsuccessful requests. Delays between retries are governed by a retry strategy.
+    Once a request fails, a retries-strategy object is created from the provided retries class.
+    This object is then queried to provide the delay in seconds (via 'get_delay(response)').
+
+    The retry object should be an instance of BaseRetries.
+    """
+
     def handle_request(self, *args, **kwargs):
         retry_strategy = None
-        retry_interval = 0
-        while retry_interval is not None:
-            if retry_interval:
-                sleep(retry_interval)
+        retry_delay = 0
+        while retry_delay is not None:
+            if retry_delay:
+                sleep(retry_delay)
 
             response = super().handle_request(*args, **kwargs)
 
-            if is_successful(response) or self.retry_strategy_cls is None:
+            if response.is_success or not self.retry_strategy_cls:
                 break
+
             if retry_strategy is None:
                 retry_strategy = self.retry_strategy_cls()
-            retry_interval = retry_strategy.get_interval(response)
+            retry_delay = retry_strategy.get_delay(response)
 
         return response
 
 
 class AsyncRetryTransport(BaseRetryTransport, AsyncHTTPTransport):
+    """Same as the RetryTransport but adapted for asynchronous clients"""
+
     async def handle_async_request(self, *args, **kwargs):
         retry_strategy = None
-        retry_interval = 0
-        while retry_interval is not None:
-            if retry_interval:
-                await anyio.sleep(retry_interval)
+        retry_delay = 0
+        while retry_delay is not None:
+            if retry_delay:
+                await anyio.sleep(retry_delay)
 
             response = await super().handle_async_request(*args, **kwargs)
 
-            if is_successful(response) or self.retry_strategy_cls is None:
+            if response.is_success or not self.retry_strategy_cls:
                 break
+
             if retry_strategy is None:
                 retry_strategy = self.retry_strategy_cls()
-            retry_interval = retry_strategy.get_interval(response)
+            retry_delay = retry_strategy.get_delay(response)
 
         return response

--- a/gcapi/transports.py
+++ b/gcapi/transports.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-from functools import wraps
 from time import sleep
 from typing import Callable, Optional, Tuple
 
@@ -63,7 +62,6 @@ class RetryTransport(BaseRetryTransport, httpx.HTTPTransport):
     The retry object should be an instance of BaseRetries.
     """
 
-    @wraps(httpx.HTTPTransport.handle_request)
     def handle_request(
         self, request: httpx.Request, *args, **kwargs
     ) -> httpx.Response:
@@ -93,7 +91,6 @@ class RetryTransport(BaseRetryTransport, httpx.HTTPTransport):
 class AsyncRetryTransport(BaseRetryTransport, httpx.AsyncHTTPTransport):
     """Same as the RetryTransport but adapted for asynchronous clients"""
 
-    @wraps(httpx.AsyncHTTPTransport.handle_async_request)
     async def handle_async_request(
         self, request: httpx.Request, *args, **kwargs
     ) -> httpx.Response:

--- a/gcapi/transports.py
+++ b/gcapi/transports.py
@@ -68,11 +68,7 @@ class RetryTransport(BaseRetryTransport, httpx.HTTPTransport):
         self, request: httpx.Request, *args, **kwargs
     ) -> httpx.Response:
         retry_strategy = None
-        retry_delay: Optional[Seconds] = 0
         while True:
-            if retry_delay:
-                sleep(retry_delay)
-
             response = super().handle_request(request, *args, **kwargs)
 
             if response.is_success or not self.retry_strategy:
@@ -89,7 +85,7 @@ class RetryTransport(BaseRetryTransport, httpx.HTTPTransport):
             else:
                 # Close any connections kept open for this request
                 response.close()
-                continue
+                sleep(retry_delay)
 
         return response
 
@@ -102,11 +98,7 @@ class AsyncRetryTransport(BaseRetryTransport, httpx.AsyncHTTPTransport):
         self, request: httpx.Request, *args, **kwargs
     ) -> httpx.Response:
         retry_strategy = None
-        retry_delay: Optional[Seconds] = 0
         while True:
-            if retry_delay:
-                await asyncio.sleep(retry_delay)
-
             response = await super().handle_async_request(
                 request, *args, **kwargs
             )
@@ -124,6 +116,6 @@ class AsyncRetryTransport(BaseRetryTransport, httpx.AsyncHTTPTransport):
             else:
                 # Close any connections kept open for this request
                 await response.aclose()
-                continue
+                await asyncio.sleep(retry_delay)
 
         return response

--- a/gcapi/transports.py
+++ b/gcapi/transports.py
@@ -1,0 +1,65 @@
+from time import sleep
+
+import anyio
+import httpx
+
+from gcapi.retries import RetryStrategy
+
+
+def is_successful(response):
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError:
+        return False
+    else:
+        return True
+
+
+class RetryTransport(httpx.BaseTransport):
+    def __init__(self, retries, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if retries is not None and not issubclass(retries, RetryStrategy):
+            raise ValueError(
+                "Provided retries strategy should be None or an instance of RetryStrategy"
+            )
+        self.retries_cls = retries
+
+    def handle_request(self, *args, **kwargs):
+        if self.retries_cls is None:
+            return super().handle_request(*args, **kwargs)
+
+        retries = self.retries_cls()
+        interval_ms = 0
+        while interval_ms is not None:
+            sleep(interval_ms / 1000)
+            response = super().handle_request(*args, **kwargs)
+            if is_successful(response):
+                break
+            interval_ms = retries.get_interval_ms(response)
+
+        return response
+
+
+class AsyncRetryTransport(httpx.AsyncBaseTransport):
+    def __init__(self, retries, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if retries is not None and not issubclass(retries, RetryStrategy):
+            raise ValueError(
+                "Provided retries strategy should be None or an instance of RetryStrategy"
+            )
+        self.retries_cls = retries
+
+    async def handle_async_request(self, *args, **kwargs):
+        if self.retries_cls is None:
+            return await super().handle_async_request(*args, **kwargs)
+
+        retries = self.retries_cls()
+        interval_ms = 0
+        while interval_ms is not None:
+            await anyio.sleep(interval_ms / 1000)
+            response = await super().handle_async_request(*args, **kwargs)
+            if is_successful(response):
+                break
+            interval_ms = retries.get_interval_ms(response)
+
+        return response

--- a/tests/test_async_transports.py
+++ b/tests/test_async_transports.py
@@ -2,10 +2,10 @@ import pytest
 
 from gcapi.transports import AsyncRetryTransport
 from tests.test_transports import (
-    MOCK_RESPONSES,
     MOCK_REQUEST,
-    NoRetries,
+    MOCK_RESPONSES,
     EndlessRetries,
+    NoRetries,
 )
 from tests.utils import mock_transport_responses
 
@@ -13,12 +13,12 @@ from tests.utils import mock_transport_responses
 @pytest.mark.anyio
 async def test_invalid_retries():
     with pytest.raises(ValueError):
-        AsyncRetryTransport(retries=object)
+        AsyncRetryTransport(retry_strategy=object)
 
 
 @pytest.mark.anyio
 async def test_null_retries():
-    transport = AsyncRetryTransport(retries=None)
+    transport = AsyncRetryTransport(retry_strategy=None)
 
     with mock_transport_responses(transport, MOCK_RESPONSES) as mock_info:
         response = await transport.handle_async_request(request=MOCK_REQUEST)
@@ -28,7 +28,7 @@ async def test_null_retries():
 
 @pytest.mark.anyio
 async def test_no_retry_strategy():
-    transport = AsyncRetryTransport(retries=NoRetries)
+    transport = AsyncRetryTransport(retry_strategy=NoRetries)
 
     with mock_transport_responses(transport, MOCK_RESPONSES) as mock_info:
         response = await transport.handle_async_request(request=MOCK_REQUEST)
@@ -38,7 +38,7 @@ async def test_no_retry_strategy():
 
 @pytest.mark.anyio
 async def test_infinite_retry_strategy():
-    transport = AsyncRetryTransport(retries=EndlessRetries)
+    transport = AsyncRetryTransport(retry_strategy=EndlessRetries)
 
     with mock_transport_responses(transport, MOCK_RESPONSES) as mock_info:
         response = await transport.handle_async_request(request=MOCK_REQUEST)

--- a/tests/test_async_transports.py
+++ b/tests/test_async_transports.py
@@ -1,16 +1,13 @@
 import pytest
-from httpx import Response, codes, Request
 
-from gcapi.retries import RetryStrategy
 from gcapi.transports import AsyncRetryTransport
-from tests.utils import mock_base_transport_responses
-
-MOCK_REQUEST = Request("GET", "https://example.com")
-MOCK_RESPONSES = [
-    Response(codes.NOT_FOUND),
-    Response(codes.NOT_FOUND),
-    Response(codes.OK),
-]
+from tests.test_transports import (
+    MOCK_RESPONSES,
+    MOCK_REQUEST,
+    NoRetries,
+    EndlessRetries,
+)
+from tests.utils import mock_transport_responses
 
 
 @pytest.mark.anyio
@@ -23,9 +20,7 @@ async def test_invalid_retries():
 async def test_null_retries():
     transport = AsyncRetryTransport(retries=None)
 
-    with mock_base_transport_responses(
-        transport, MOCK_RESPONSES, asynchronous=True
-    ) as mock_info:
+    with mock_transport_responses(transport, MOCK_RESPONSES) as mock_info:
         response = await transport.handle_async_request(request=MOCK_REQUEST)
         assert response is MOCK_RESPONSES[0]
         assert mock_info.num_requests == 1
@@ -33,15 +28,9 @@ async def test_null_retries():
 
 @pytest.mark.anyio
 async def test_no_retry_strategy():
-    class NoRetries(RetryStrategy):
-        def get_interval_ms(self, *_, **__):
-            return None
-
     transport = AsyncRetryTransport(retries=NoRetries)
 
-    with mock_base_transport_responses(
-        transport, MOCK_RESPONSES, asynchronous=True
-    ) as mock_info:
+    with mock_transport_responses(transport, MOCK_RESPONSES) as mock_info:
         response = await transport.handle_async_request(request=MOCK_REQUEST)
         assert response is MOCK_RESPONSES[0]
         assert mock_info.num_requests == 1
@@ -49,15 +38,9 @@ async def test_no_retry_strategy():
 
 @pytest.mark.anyio
 async def test_infinite_retry_strategy():
-    class EndlessRetries(RetryStrategy):
-        def get_interval_ms(self, *_, **__):
-            return 0
-
     transport = AsyncRetryTransport(retries=EndlessRetries)
 
-    with mock_base_transport_responses(
-        transport, MOCK_RESPONSES, asynchronous=True
-    ) as mock_info:
+    with mock_transport_responses(transport, MOCK_RESPONSES) as mock_info:
         response = await transport.handle_async_request(request=MOCK_REQUEST)
         assert response is MOCK_RESPONSES[-1]
-        assert mock_info.num_requests == 3
+        assert mock_info.num_requests == len(MOCK_RESPONSES)

--- a/tests/test_async_transports.py
+++ b/tests/test_async_transports.py
@@ -1,0 +1,63 @@
+import pytest
+from httpx import Response, codes, Request
+
+from gcapi.retries import RetryStrategy
+from gcapi.transports import AsyncRetryTransport
+from tests.utils import mock_base_transport_responses
+
+MOCK_REQUEST = Request("GET", "https://example.com")
+MOCK_RESPONSES = [
+    Response(codes.NOT_FOUND),
+    Response(codes.NOT_FOUND),
+    Response(codes.OK),
+]
+
+
+@pytest.mark.anyio
+async def test_invalid_retries():
+    with pytest.raises(ValueError):
+        AsyncRetryTransport(retries=object)
+
+
+@pytest.mark.anyio
+async def test_null_retries():
+    transport = AsyncRetryTransport(retries=None)
+
+    with mock_base_transport_responses(
+        transport, MOCK_RESPONSES, asynchronous=True
+    ) as mock_info:
+        response = await transport.handle_async_request(request=MOCK_REQUEST)
+        assert response is MOCK_RESPONSES[0]
+        assert mock_info.num_requests == 1
+
+
+@pytest.mark.anyio
+async def test_no_retry_strategy():
+    class NoRetries(RetryStrategy):
+        def get_interval_ms(self, *_, **__):
+            return None
+
+    transport = AsyncRetryTransport(retries=NoRetries)
+
+    with mock_base_transport_responses(
+        transport, MOCK_RESPONSES, asynchronous=True
+    ) as mock_info:
+        response = await transport.handle_async_request(request=MOCK_REQUEST)
+        assert response is MOCK_RESPONSES[0]
+        assert mock_info.num_requests == 1
+
+
+@pytest.mark.anyio
+async def test_infinite_retry_strategy():
+    class EndlessRetries(RetryStrategy):
+        def get_interval_ms(self, *_, **__):
+            return 0
+
+    transport = AsyncRetryTransport(retries=EndlessRetries)
+
+    with mock_base_transport_responses(
+        transport, MOCK_RESPONSES, asynchronous=True
+    ) as mock_info:
+        response = await transport.handle_async_request(request=MOCK_REQUEST)
+        assert response is MOCK_RESPONSES[-1]
+        assert mock_info.num_requests == 3

--- a/tests/test_async_transports.py
+++ b/tests/test_async_transports.py
@@ -12,7 +12,7 @@ from tests.utils import mock_transport_responses
 
 @pytest.mark.anyio
 async def test_invalid_retries():
-    with pytest.raises(ValueError):
+    with pytest.raises(RuntimeError):
         AsyncRetryTransport(retry_strategy=object)
 
 

--- a/tests/test_retries.py
+++ b/tests/test_retries.py
@@ -4,7 +4,6 @@ from httpx import Response, codes
 from gcapi.retries import SelectiveBackoffStrategy
 
 NO_RETRIES = [None]
-SINGLE_RETRY = [0, None]
 
 
 @pytest.mark.parametrize(
@@ -26,14 +25,6 @@ SINGLE_RETRY = [0, None]
             ],
             NO_RETRIES,
         ),
-        (
-            [Response(codes.FORBIDDEN)] * 2,
-            SINGLE_RETRY,
-        ),
-        (
-            [Response(codes.NOT_FOUND)] * 2,
-            SINGLE_RETRY,
-        ),
         *(  # Backoff responses
             (
                 [Response(e)] * 10,
@@ -49,15 +40,14 @@ SINGLE_RETRY = [0, None]
         ),
         (  # Mixed responses
             [
-                Response(codes.FORBIDDEN),
                 Response(codes.INTERNAL_SERVER_ERROR),
                 Response(codes.INTERNAL_SERVER_ERROR),
                 Response(codes.BAD_GATEWAY),
                 Response(codes.BAD_GATEWAY),
-                Response(codes.NOT_FOUND),
-                Response(codes.FORBIDDEN),
+                Response(codes.GATEWAY_TIMEOUT),
+                Response(codes.GATEWAY_TIMEOUT),
             ],
-            [0, 0.1, 0.2, 0.1, 0.2, 0, None],
+            [0.1, 0.2] * 3,
         ),
     ],
 )

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -1,7 +1,7 @@
 import httpx
 import pytest
 
-from gcapi.retries import BaseRetries
+from gcapi.retries import BaseRetryStrategy
 from gcapi.transports import RetryTransport
 from tests.utils import mock_transport_responses
 
@@ -13,13 +13,13 @@ MOCK_RESPONSES = [
 ]
 
 
-class NoRetries(BaseRetries):
+class NoRetries(BaseRetryStrategy):
     @staticmethod
     def get_delay(*_, **__):
         return None
 
 
-class EndlessRetries(BaseRetries):
+class EndlessRetries(BaseRetryStrategy):
     @staticmethod
     def get_delay(*_, **__):
         return 0
@@ -27,11 +27,11 @@ class EndlessRetries(BaseRetries):
 
 def test_invalid_retries():
     with pytest.raises(ValueError):
-        RetryTransport(retries=object)
+        RetryTransport(retry_strategy=object)
 
 
 def test_null_retries():
-    transport = RetryTransport(retries=None)
+    transport = RetryTransport(retry_strategy=None)
 
     with mock_transport_responses(transport, MOCK_RESPONSES) as mock_info:
         response = transport.handle_request(request=MOCK_REQUEST)
@@ -40,7 +40,7 @@ def test_null_retries():
 
 
 def test_no_retry_strategy():
-    transport = RetryTransport(retries=NoRetries)
+    transport = RetryTransport(retry_strategy=NoRetries)
 
     with mock_transport_responses(transport, MOCK_RESPONSES) as mock_info:
         response = transport.handle_request(request=MOCK_REQUEST)
@@ -49,7 +49,7 @@ def test_no_retry_strategy():
 
 
 def test_infinite_retry_strategy():
-    transport = RetryTransport(retries=EndlessRetries)
+    transport = RetryTransport(retry_strategy=EndlessRetries)
 
     with mock_transport_responses(transport, MOCK_RESPONSES) as mock_info:
         response = transport.handle_request(request=MOCK_REQUEST)

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -1,7 +1,7 @@
 import httpx
 import pytest
 
-from gcapi.retries import RetryStrategy
+from gcapi.retries import BaseRetries
 from gcapi.transports import RetryTransport
 from tests.utils import mock_transport_responses
 
@@ -13,15 +13,15 @@ MOCK_RESPONSES = [
 ]
 
 
-class NoRetries(RetryStrategy):
+class NoRetries(BaseRetries):
     @staticmethod
-    def get_interval(*_, **__):
+    def get_delay(*_, **__):
         return None
 
 
-class EndlessRetries(RetryStrategy):
+class EndlessRetries(BaseRetries):
     @staticmethod
-    def get_interval(*_, **__):
+    def get_delay(*_, **__):
         return 0
 
 

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -26,7 +26,7 @@ class EndlessRetries(BaseRetryStrategy):
 
 
 def test_invalid_retries():
-    with pytest.raises(ValueError):
+    with pytest.raises(RuntimeError):
         RetryTransport(retry_strategy=object)
 
 

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -1,0 +1,53 @@
+import httpx
+import pytest
+
+from gcapi.retries import RetryStrategy
+from gcapi.transports import RetryTransport
+from tests.utils import mock_base_transport_responses
+
+MOCK_REQUEST = httpx.Request("GET", "https://example.com")
+MOCK_RESPONSES = [
+    httpx.Response(httpx.codes.NOT_FOUND),
+    httpx.Response(httpx.codes.NOT_FOUND),
+    httpx.Response(httpx.codes.OK),
+]
+
+
+def test_invalid_retries():
+    with pytest.raises(ValueError):
+        RetryTransport(retries=object)
+
+
+def test_null_retries():
+    transport = RetryTransport(retries=None)
+
+    with mock_base_transport_responses(transport, MOCK_RESPONSES) as mock_info:
+        response = transport.handle_request(request=MOCK_REQUEST)
+        assert response is MOCK_RESPONSES[0]
+        assert mock_info.num_requests == 1
+
+
+def test_no_retry_strategy():
+    class NoRetries(RetryStrategy):
+        def get_interval_ms(self, *_, **__):
+            return None
+
+    transport = RetryTransport(retries=NoRetries)
+
+    with mock_base_transport_responses(transport, MOCK_RESPONSES) as mock_info:
+        response = transport.handle_request(request=MOCK_REQUEST)
+        assert response is MOCK_RESPONSES[0]
+        assert mock_info.num_requests == 1
+
+
+def test_infinite_retry_strategy():
+    class EndlessRetries(RetryStrategy):
+        def get_interval_ms(self, *_, **__):
+            return 0
+
+    transport = RetryTransport(retries=EndlessRetries)
+
+    with mock_base_transport_responses(transport, MOCK_RESPONSES) as mock_info:
+        response = transport.handle_request(request=MOCK_REQUEST)
+        assert response is MOCK_RESPONSES[-1]
+        assert mock_info.num_requests == 3

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,11 +1,7 @@
 import contextlib
 from time import sleep
 
-from httpx import (
-    HTTPStatusError,
-    AsyncHTTPTransport,
-    HTTPTransport,
-)
+from httpx import AsyncHTTPTransport, HTTPStatusError, HTTPTransport
 
 
 def recurse_call(func):
@@ -41,10 +37,12 @@ def async_recurse_call(func):
 @contextlib.contextmanager
 def mock_transport_responses(transport, responses):
     """
-    Mocks the responses in the provided HTTPX transport by shadowing the request handlers
-    just before the HTTPTransport or AsyncHTTPTransport in the transport's MRO.
+    Mocks the responses in the provided HTTPX transport by
+    shadowing the request handlers just before the HTTPTransport
+    or AsyncHTTPTransport in the transport's MRO.
 
-    Returns a class from which some metadata about the mocking can be read (such as number of requests).
+    Returns a class from which some metadata about the mocking can
+    be read (such as number of requests).
     """
     responses = iter(responses)
 
@@ -59,8 +57,8 @@ def mock_transport_responses(transport, responses):
                 response = responses.__next__()
                 response.request = request
                 return response
-            except StopIteration:
-                raise RuntimeError("Ran out of mock responses")
+            except StopIteration as e:
+                raise RuntimeError("Ran out of mock responses") from e
 
         async def handle_async_request(self, *args, **kwargs):
             return self.handle_request(*args, **kwargs)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,7 @@
+import contextlib
 from time import sleep
 
-from httpx import HTTPStatusError
+from httpx import HTTPStatusError, BaseTransport, AsyncBaseTransport
 
 
 def recurse_call(func):
@@ -31,3 +32,47 @@ def async_recurse_call(func):
         return result
 
     return wrapper
+
+
+@contextlib.contextmanager
+def mock_base_transport_responses(
+    transport, mock_responses, asynchronous=False
+):
+    mock_responses = iter(mock_responses)
+    shadow_base_class = (
+        BaseTransport if not asynchronous else AsyncBaseTransport
+    )
+
+    class ResponseMetaData:
+        num_requests = 0
+
+    class MockTransport:
+        @staticmethod
+        def handle_request(request, *_, **__):
+            try:
+                ResponseMetaData.num_requests += 1
+                response = mock_responses.__next__()
+                response.request = request
+                return response
+            except StopIteration:
+                raise RuntimeError("Ran out of mock responses")
+
+        async def handle_async_request(self, *args, **kwargs):
+            return self.handle_request(*args, **kwargs)
+
+    bases = []
+    for cls in transport.__class__.mro():
+        if cls is shadow_base_class:
+            bases.append(MockTransport)
+        bases.append(cls)
+    old_class = transport.__class__
+    new_class = type(
+        old_class.__name__,
+        tuple(bases),
+        dict(old_class.__dict__),
+    )
+    try:
+        transport.__class__ = new_class
+        yield ResponseMetaData
+    finally:
+        transport.__class__ = old_class


### PR DESCRIPTION
Related:
- https://github.com/DIAGNijmegen/rse-cirrus-core/issues/1675

This PR adds retries for requests made to grand challenge.

~A client will retry `403` (_Forbidden_), and `404` (_Not Found_) once without delay. The rationale is that there might be a split-second delay in permission propagation that is covered by regular latency.~ Edit: it now only retries 5xx.

Several transient server errors (i.e. `5xx`) are retried with an exponential backoff delay in seconds: 0.1, 0.2, 0.4, 0.8, 1.60, 3.20, 6.40, 12.8. With a typical total retry time of ~26s., but the exact retry duration depends on the type of responses and their order.

A **custom** retry strategy can be provided to the client as long as a call of the provided strategy results in an object that inherits from the `BaseRetryStrategy` and implements a `get_delay(response)` method.
