### PR TITLE
More Data Models

### DIFF
--- a/gcapi/apibase.py
+++ b/gcapi/apibase.py
@@ -146,9 +146,10 @@ class APIBase(Generic[T], Common[T]):
     def detail(
         self, pk=None, api_url=None, **params
     ) -> Generator[T, dict[Any, Any], T]:
-        if all((pk, params)):
-            raise ValueError("Only one of pk or params must be specified")
-
+        if sum(bool(arg) for arg in [pk, api_url, params]) != 1:
+            raise ValueError(
+                "Exactly one of pk, api_url, or params must be specified"
+            )
         if pk is not None or api_url is not None:
             if pk is not None:
                 request_kwargs = dict(path=urljoin(self.base_path, pk + "/"))

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -368,7 +368,7 @@ def test_get_reader_study_by_slug(local_grand_challenge):
     assert by_pk == by_slug == by_api_url
 
 
-@pytest.mark.parametrize("key", ["slug", "pk"])
+@pytest.mark.parametrize("key", ["slug", "pk", "api_url"])
 def test_detail_no_objects(local_grand_challenge, key):
     c = Client(
         base_url=local_grand_challenge, verify=False, token=READERSTUDY_TOKEN
@@ -376,6 +376,24 @@ def test_detail_no_objects(local_grand_challenge, key):
 
     with pytest.raises(ObjectNotFound):
         c.reader_studies.detail(**{key: "foo"})
+
+
+@pytest.mark.parametrize(
+    "keys",
+    (
+        ("api_url", "pk", "slug"),
+        ("api_url", "pk"),
+        ("api_url", "slug"),
+        ("pk", "slug"),
+    ),
+)
+def test_detail_multiple_args(local_grand_challenge, keys):
+    c = Client(
+        base_url=local_grand_challenge, verify=False, token=READERSTUDY_TOKEN
+    )
+
+    with pytest.raises(ValueError):
+        c.reader_studies.detail(**{k: "foo" for k in keys})
 
 
 def test_detail_multiple_objects(local_grand_challenge):

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -368,14 +368,25 @@ def test_get_reader_study_by_slug(local_grand_challenge):
     assert by_pk == by_slug == by_api_url
 
 
-@pytest.mark.parametrize("key", ["slug", "pk", "api_url"])
-def test_detail_no_objects(local_grand_challenge, key):
+@pytest.mark.parametrize(
+    "keys",
+    [
+        {"slug": "foo"},
+        {"pk": "foo"},
+        {"api_url": "foo"},
+    ],
+)
+def test_detail_no_objects(local_grand_challenge, keys):
     c = Client(
         base_url=local_grand_challenge, verify=False, token=READERSTUDY_TOKEN
     )
+    if "api_url" in keys:
+        keys = {
+            "api_url": f"{local_grand_challenge}/reader-studies/{keys['api_url']}"
+        }
 
     with pytest.raises(ObjectNotFound):
-        c.reader_studies.detail(**{key: "foo"})
+        c.reader_studies.detail(**keys)
 
 
 @pytest.mark.parametrize(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -22,7 +22,8 @@ def recurse_call(func):
             except (
                 HTTPStatusError,
                 ValueError,
-                ObjectNotFound,  # Lagging permissions
+                # Permissions are sometimes delayed, shows as ObjectNotFound
+                ObjectNotFound,
             ) as e:
                 last_error = e
                 sleep(0.5)
@@ -43,7 +44,8 @@ def async_recurse_call(func):
             except (
                 HTTPStatusError,
                 ValueError,
-                ObjectNotFound,  # Lagging permissions
+                # Permissions are sometimes delayed, shows as ObjectNotFound
+                ObjectNotFound,
             ) as e:
                 last_error = e
                 sleep(0.5)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,6 +3,7 @@ from time import sleep
 
 from httpx import AsyncHTTPTransport, HTTPStatusError, HTTPTransport
 
+from gcapi.exceptions import ObjectNotFound
 from tests.scripts.constants import USER_TOKENS
 
 ADMIN_TOKEN = USER_TOKENS["admin"]
@@ -18,7 +19,11 @@ def recurse_call(func):
             try:
                 result = func(*args, **kwargs)
                 break
-            except (HTTPStatusError, ValueError) as e:
+            except (
+                HTTPStatusError,
+                ValueError,
+                ObjectNotFound,  # Lagging permissions
+            ) as e:
                 last_error = e
                 sleep(0.5)
         else:
@@ -35,7 +40,11 @@ def async_recurse_call(func):
             try:
                 result = await func(*args, **kwargs)
                 break
-            except (HTTPStatusError, ValueError) as e:
+            except (
+                HTTPStatusError,
+                ValueError,
+                ObjectNotFound,  # Lagging permissions
+            ) as e:
                 last_error = e
                 sleep(0.5)
         else:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,14 +13,16 @@ ARCHIVE_TOKEN = USER_TOKENS["archive"]
 
 def recurse_call(func):
     def wrapper(*args, **kwargs):
+        last_error = None
         for _ in range(60):
             try:
                 result = func(*args, **kwargs)
                 break
-            except (HTTPStatusError, ValueError):
+            except (HTTPStatusError, ValueError) as e:
+                last_error = e
                 sleep(0.5)
         else:
-            raise TimeoutError
+            raise TimeoutError from last_error
         return result
 
     return wrapper
@@ -28,14 +30,16 @@ def recurse_call(func):
 
 def async_recurse_call(func):
     async def wrapper(*args, **kwargs):
+        last_error = None
         for _ in range(60):
             try:
                 result = await func(*args, **kwargs)
                 break
-            except (HTTPStatusError, ValueError):
+            except (HTTPStatusError, ValueError) as e:
+                last_error = e
                 sleep(0.5)
         else:
-            raise TimeoutError
+            raise TimeoutError from last_error
         return result
 
     return wrapper


### PR DESCRIPTION
This PR contains some extracted (or more re-achieved) changes from:

- https://github.com/DIAGNijmegen/rse-gcapi/pull/167

When I was doing a major re-haul and unwisely decided that, since I was touching nearly everything, it made most sense to push the changes upon the already large change set.

This PR does two major things:
- Allow object/model retrieval using `api_url` (was done with the direct request, now forced through the APIs)
- Fix resulting deprecation warnings on key access (i.e. `object["pk"]`

It also makes the recurse_call wrapper more robust by outputting the error (`raise from e`) and allowing for retries when `ObjectNotFound` is thrown.

Widespread changeset, but relatively simple changes.