### PR TITLE
Update archiveItem helper functions

### DIFF
--- a/gcapi/apibase.py
+++ b/gcapi/apibase.py
@@ -220,7 +220,7 @@ class ModifiableMixin(Common):
 
     def partial_update(self, pk, **kwargs):
         result = yield from self.perform_request("PATCH", pk=pk, data=kwargs)
-        return result
+        return self.response_model(**result)
 
     def delete(self, pk):
         return (yield from self.perform_request("DELETE", pk=pk))

--- a/gcapi/client.py
+++ b/gcapi/client.py
@@ -721,7 +721,7 @@ class ClientBase(ApiDefinitions, ClientInterface):
             if interfaces.get(slug):
                 interface = interfaces[slug]
             else:
-                interface = yield from self._fetch_interface(slug)
+                interface = yield from self._fetch_socket_detail(slug)
                 interfaces[slug] = interface
             super_kind = interface.super_kind.casefold()
             if super_kind != "value":

--- a/gcapi/client.py
+++ b/gcapi/client.py
@@ -958,7 +958,7 @@ class ClientBase(ApiDefinitions, ClientInterface):
         interface_cache: dict[str, gcapi.models.ComponentInterface] = {}
 
         # Firstly, prepare ALL the strategies
-        strategy_collections: list[list[SocketValueCreateStrategy]] = []
+        strategies_per_value_set: list[list[SocketValueCreateStrategy]] = []
         for description in descriptions:
             strategy_per_value = []
 
@@ -977,14 +977,14 @@ class ClientBase(ApiDefinitions, ClientInterface):
                 strategy.prepare()
                 strategy_per_value.append(strategy)
 
-            strategy_collections.append(strategy_per_value)
+            strategies_per_value_set.append(strategy_per_value)
 
         # Secondly, create + update socket-value sets
         socket_value_sets: list[SocketValueSet] = []
-        for collection in strategy_collections:
+        for strategies in strategies_per_value_set:
             socket_value_set = yield from api.create(**creation_kwargs)
             values = []
-            for strategy in collection:
+            for strategy in strategies:
                 strategy.parent = socket_value_set
                 post_value = yield from strategy()
                 if post_value is not Empty:

--- a/gcapi/client.py
+++ b/gcapi/client.py
@@ -715,6 +715,37 @@ class ClientBase(ApiDefinitions, ClientInterface):
 
         return (yield from self.__org_api_meta.algorithm_jobs.create(**job))
 
+    def _validate_display_set_values(self, values, interfaces):
+        invalid_file_paths = {}
+        for slug, value in values:
+            if interfaces.get(slug):
+                interface = interfaces[slug]
+            else:
+                interface = yield from self._fetch_interface(slug)
+                interfaces[slug] = interface
+            super_kind = interface.super_kind.casefold()
+            if super_kind != "value":
+                if not isinstance(value, list):
+                    raise ValueError(
+                        f"Values for {slug} ({super_kind}) "
+                        "should be a list of file paths."
+                    )
+                if super_kind != "image" and len(value) > 1:
+                    raise ValueError(
+                        f"You can only upload one single file "
+                        f"to interface {slug} ({super_kind})."
+                    )
+                for file_path in value:
+                    if not Path(file_path).exists():
+                        invalid_file_paths[slug] = invalid_file_paths.get(
+                            slug, []
+                        )
+                        invalid_file_paths[slug].append(str(file_path))
+        if invalid_file_paths:
+            raise ValueError(f"Invalid file paths: {invalid_file_paths}")
+
+        return interfaces
+
     def add_cases_to_reader_study(
         self, *, reader_study: str, display_sets: list[dict[str, Any]]
     ):
@@ -781,37 +812,6 @@ class ClientBase(ApiDefinitions, ClientInterface):
 
             res.append(ds.pk)
         return res  # noqa: B901
-
-    def _validate_display_set_values(self, values, interfaces):
-        invalid_file_paths = {}
-        for slug, value in values:
-            if interfaces.get(slug):
-                interface = interfaces[slug]
-            else:
-                interface = yield from self._fetch_interface(slug)
-                interfaces[slug] = interface
-            super_kind = interface.super_kind.casefold()
-            if super_kind != "value":
-                if not isinstance(value, list):
-                    raise ValueError(
-                        f"Values for {slug} ({super_kind}) "
-                        "should be a list of file paths."
-                    )
-                if super_kind != "image" and len(value) > 1:
-                    raise ValueError(
-                        f"You can only upload one single file "
-                        f"to interface {slug} ({super_kind})."
-                    )
-                for file_path in value:
-                    if not Path(file_path).exists():
-                        invalid_file_paths[slug] = invalid_file_paths.get(
-                            slug, []
-                        )
-                        invalid_file_paths[slug].append(str(file_path))
-        if invalid_file_paths:
-            raise ValueError(f"Invalid file paths: {invalid_file_paths}")
-
-        return interfaces
 
     def update_archive_item(
         self, *, archive_item_pk: str, values: SocketValueSetDescription

--- a/gcapi/create_strategies.py
+++ b/gcapi/create_strategies.py
@@ -5,7 +5,6 @@ from typing import Optional, Union
 
 import httpx
 
-from gcapi.client import ClientBase
 from gcapi.models import (
     Algorithm,
     ArchiveItem,
@@ -200,6 +199,8 @@ class FileSocketValueCreateStrategy(SocketValueCreateStrategy):
         self.content_name = self.socket.relative_path
 
     def _create_from_socket(self, post_request):
+        from gcapi.client import ClientBase
+
         # Cannot link a file directly to file, so we download it first
         response_or_json = yield from ClientBase.__call__(
             self.client,

--- a/gcapi/gcapi.py
+++ b/gcapi/gcapi.py
@@ -128,6 +128,11 @@ class Client(httpx.Client, WrapApiInterfaces, ClientBase):
     def run_external_job(self, *args, **kwargs):
         return self._wrap_function(super().run_external_job)(*args, **kwargs)
 
+    def add_cases_to_archive(self, *args, **kwargs):
+        return self._wrap_function(super().add_cases_to_archive)(
+            *args, **kwargs
+        )
+
     def update_archive_item(self, *args, **kwargs):
         return self._wrap_function(super().update_archive_item)(
             *args, **kwargs
@@ -181,6 +186,11 @@ class AsyncClient(httpx.AsyncClient, WrapApiInterfaces, ClientBase):
 
     async def run_external_job(self, *args, **kwargs):
         return await self._wrap_function(super().run_external_job)(
+            *args, **kwargs
+        )
+
+    async def add_cases_to_archive(self, *args, **kwargs):
+        return await self._wrap_function(super().add_cases_to_archive)(
             *args, **kwargs
         )
 

--- a/tests/async_integration_tests.py
+++ b/tests/async_integration_tests.py
@@ -519,8 +519,11 @@ async def test_add_and_update_file_to_archive_item(local_grand_challenge):
 
         item_updated = await get_updated_archive_item()
 
-        csv_socket_value = item_updated.values[0]
-        assert csv_socket_value.interface.slug == "predictions-csv-file"
+        csv_socket_value = next(
+            v
+            for v in item_updated.values
+            if v.interface.slug == "predictions-csv-file"
+        )
         assert "test.csv" in csv_socket_value.file
 
         updated_socket_value_count = len(item_updated.values)
@@ -544,8 +547,11 @@ async def test_add_and_update_file_to_archive_item(local_grand_challenge):
         item_updated_again = await get_updated_again_archive_item()
 
         assert len(item_updated_again.values) == updated_socket_value_count
-        new_csv_socket_value = item_updated_again.values[0]
-        assert new_csv_socket_value.interface.slug == "predictions-csv-file"
+        new_csv_socket_value = next(
+            v
+            for v in item_updated_again.values
+            if v.interface.slug == "predictions-csv-file"
+        )
         assert "test2.csv" in new_csv_socket_value.file
 
 

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -482,8 +482,11 @@ def test_add_and_update_file_to_archive_item(local_grand_challenge):
 
     item_updated = get_updated_archive_item()
 
-    csv_socket_value = item_updated.values[0]
-    assert csv_socket_value.interface.slug == "predictions-csv-file"
+    csv_socket_value = next(
+        v
+        for v in item_updated.values
+        if v.interface.slug == "predictions-csv-file"
+    )
     assert "test.csv" in csv_socket_value.file
 
     updated_socket_value_count = len(item_updated.values)
@@ -507,7 +510,11 @@ def test_add_and_update_file_to_archive_item(local_grand_challenge):
     item_updated_again = get_updated_again_archive_item()
 
     assert len(item_updated_again.values) == updated_socket_value_count
-    new_csv_socket_value = item_updated_again.values[0]
+    new_csv_socket_value = next(
+        v
+        for v in item_updated_again.values
+        if v.interface.slug == "predictions-csv-file"
+    )
     assert new_csv_socket_value.interface.slug == "predictions-csv-file"
     assert "test2.csv" in new_csv_socket_value.file
 


### PR DESCRIPTION
Hooks the archive_item helper functions into the socket strategies.

The existing `update_archive_item` and the new `add_cases_to_archive` (new: similar level as the `add_cases_to_reader_study`).

Merge note: to keep things reviewable I am limiting the change set per category of helper functions. Still needs the target to be merged though.

Dependent on the GC counter-part:
- https://github.com/comic/grand-challenge.org/pull/4030
