### PR TITLE
Add a retry-transport to gc file getter

### DIFF
--- a/gcapi/retries.py
+++ b/gcapi/retries.py
@@ -1,3 +1,5 @@
+import datetime
+from email.utils import parsedate_to_datetime
 from typing import Optional
 
 import httpx
@@ -47,15 +49,41 @@ class SelectiveBackoffStrategy(BaseRetryStrategy):
             codes.SERVICE_UNAVAILABLE,
             codes.GATEWAY_TIMEOUT,
             codes.INSUFFICIENT_STORAGE,
+            codes.TOO_MANY_REQUESTS,
         ):
-            return self._backoff_retries(latest_response.status_code)
+            return self._backoff_retries(latest_response)
         else:
             return NO_RETRY
 
-    def _backoff_retries(self, code):
-        num_retries = self.earlier_number_of_retries.get(code, 0)
+    def _backoff_retries(self, response):
+        num_retries = self.earlier_number_of_retries.get(
+            response.status_code, 0
+        )
         if num_retries >= self.maximum_number_of_retries:
             return NO_RETRY
         else:
-            self.earlier_number_of_retries[code] = num_retries + 1
-            return self.backoff_factor * (2**num_retries)
+            self.earlier_number_of_retries[response.status_code] = (
+                num_retries + 1
+            )
+            delay = self.backoff_factor * (2**num_retries)
+
+            if "Retry-After" in response.headers:
+                retry_after = response.headers["Retry-After"]
+                # The HTTP header comes in two formats: integer seconds and HTTP-date
+                try:
+                    # Try to parse as integer seconds
+                    delay = float(retry_after)
+                except ValueError:
+                    # Try to parse as HTTP-date
+                    try:
+                        retry_after_dt = parsedate_to_datetime(retry_after)
+                    except ValueError:
+                        pass
+                    else:
+                        now = datetime.datetime.now(
+                            datetime.timezone.utc
+                        ).replace(tzinfo=retry_after_dt.tzinfo)
+                        delay = (retry_after_dt - now).total_seconds()
+                        delay = max(0, delay)
+
+            return delay

--- a/gcapi/retries.py
+++ b/gcapi/retries.py
@@ -77,7 +77,11 @@ class SelectiveBackoffStrategy(BaseRetryStrategy):
                     # Try to parse as HTTP-date
                     try:
                         retry_after_dt = parsedate_to_datetime(retry_after)
-                    except ValueError:
+                    except (
+                        ValueError,
+                        # Python 3.9 throws a TypeError when it cannot parse the date
+                        TypeError,
+                    ):
                         pass
                     else:
                         now = datetime.datetime.now(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -170,7 +170,12 @@ def local_grand_challenge() -> Generator[str, None, None]:
 
 def get_grand_challenge_file(repo_path: Path, output_directory: Path) -> None:
     with httpx.Client(
-        transport=httpx.HTTPTransport(retry_strategy=SelectiveBackoffStrategy)
+        transport=RetryTransport(
+            retry_strategy=SelectiveBackoffStrategy(
+                backoff_factor=0.1,
+                maximum_number_of_retries=5,
+            )
+        ),
     ) as client:
         response = client.get(
             (
@@ -178,12 +183,6 @@ def get_grand_challenge_file(repo_path: Path, output_directory: Path) -> None:
                 f"main/{repo_path}"
             ),
             follow_redirects=True,
-            transport=RetryTransport(
-                retry_strategy=SelectiveBackoffStrategy(
-                    backoff_factor=0.1,
-                    maximum_number_of_retries=5,
-                )
-            ),
         )
     response.raise_for_status()
 

--- a/tests/test_retries.py
+++ b/tests/test_retries.py
@@ -47,6 +47,47 @@ NO_RETRIES = [None]
             ],
             [0.1, 0.2] * 3,
         ),
+        # codes.TOO_MANY_REQUESTS without Retry-After header
+        (
+            [Response(codes.TOO_MANY_REQUESTS)] * 10,
+            [0.1, 0.2, 0.4, 0.8, 1.6, 3.2, 6.4, 12.8, None, None],
+        ),
+        # codes.TOO_MANY_REQUESTS with Retry-After header with garbage
+        (
+            [
+                Response(
+                    codes.TOO_MANY_REQUESTS,
+                    headers={"Retry-After": "foo"},
+                )
+            ]
+            * 10,
+            [0.1, 0.2, 0.4, 0.8, 1.6, 3.2, 6.4, 12.8, None, None],
+        ),
+        # codes.TOO_MANY_REQUESTS with Retry-After header as integer seconds
+        (
+            [
+                Response(
+                    codes.TOO_MANY_REQUESTS,
+                    headers={"Retry-After": "120"},
+                )
+            ]
+            * 10,
+            [120.0] * 8 + [None, None],
+        ),
+        # codes.TOO_MANY_REQUESTS with Retry-After header as HTTP-date
+        (
+            [
+                Response(
+                    codes.TOO_MANY_REQUESTS,
+                    headers={"Retry-After": "Wed, 21 Oct 2015 07:28:00 GMT"},
+                )
+            ]
+            * 2,
+            [
+                pytest.approx(0, abs=2),  # Will be mocked below
+                pytest.approx(0, abs=2),
+            ],
+        ),
     ],
 )
 def test_selective_backoff_strategy(responses, delays):


### PR DESCRIPTION
CI on main is failing on a Too Many Requests. Likely the CI all decided to GET github at the same time: https://github.com/DIAGNijmegen/rse-gcapi/actions/runs/15106933540/job/42457511133

This PR does a quick n-dirty patch of the retry transports the gcapi client already uses to respect "Retry-After" headers and  re-uses the thos retries getting the GC files: making things more robust.