### PR TITLE
Update DisplaySet helper functions

### DIFF
--- a/gcapi/client.py
+++ b/gcapi/client.py
@@ -798,8 +798,9 @@ class ClientBase(ApiDefinitions, ClientInterface):
                 https://grand-challenge.org/reader-studies/i-am-a-reader-study/
 
         display_sets
-            The format for the description of display sets is as follows:
+            The format for the descriptions of display sets are as follows:
 
+            ```python
             [
                 {
                     "slug_0": ["filepath_0", ...],
@@ -811,11 +812,29 @@ class ClientBase(ApiDefinitions, ClientInterface):
                 },
                 ...
             ]
+            ```
 
             Where the file paths are local paths to the files making up a
             single image. For file-kind sockets the file path can only
             reference a single file. For json-kind sockets any value that
-            is valid for the sockets can directly be passed.
+            is valid for the sockets can directly be passed, or a filepath
+            to a file that contain the value can be provided.
+            Existing images on Grand Challenge can be re-used by either
+            passing an API url, or a socket value (display set):
+
+            ```python
+            image = client.images.detail(pk="ad5...")
+            ds = client.reader_study.display_set.detail(pk="f5...")
+            socket_value = ds.values[0]
+
+            display_sets = [
+                {
+                    "slug_0": image.api_url,
+                    "slug_1": socket_value,
+                    "slug_1": socket_value.image.api_url,
+                }
+            ]
+            ```
 
         Returns
         -------
@@ -908,8 +927,9 @@ class ClientBase(ApiDefinitions, ClientInterface):
                 https://grand-challenge.org/archives/i-am-an-archive/
 
         archive_items
-            The format for the description of archive items is as follows:
+            The format for the descriptions of archive items are as follows:
 
+            ```python
             [
                 {
                     "slug_0": ["filepath_0", ...],
@@ -921,11 +941,29 @@ class ClientBase(ApiDefinitions, ClientInterface):
                 },
                 ...
             ]
+            ```
 
             Where the file paths are local paths to the files making up a
             single image. For file-kind sockets the file path can only
             reference a single file. For json-kind sockets any value that
-            is valid for the sockets can directly be passed.
+            is valid for the sockets can directly be passed, or a filepath
+            to a file that contain the value can be provided.
+            Existing images on Grand Challenge can be re-used by either
+            passing an API url, or a socket value (display set):
+
+            ```python
+            image = client.images.detail(pk="ad5...")
+            ds = client.reader_study.display_set.detail(pk="f5...")
+            socket_value = ds.values[0]
+
+            display_sets = [
+                {
+                    "slug_0": image.api_url,
+                    "slug_1": socket_value,
+                    "slug_1": socket_value.image.api_url,
+                }
+            ]
+            ```
 
         Returns
         -------

--- a/gcapi/client.py
+++ b/gcapi/client.py
@@ -728,6 +728,57 @@ class ClientBase(ApiDefinitions, ClientInterface):
 
         return (yield from self.__org_api_meta.algorithm_jobs.create(**job))
 
+    def update_display_set(
+        self, *, display_set_pk: str, values: SocketValueSetDescription
+    ):
+        """
+        This function updates an existing display set with the provided values
+        and returns the updated display set.
+
+        You can use this function, for example, to add metadata to an display set.
+
+        First, retrieve the display_set from your archive:
+
+        reader_study = client.reader_studies.detail(slug="...")
+        items = list(
+            client.reader_studies.display_sets.iterate_all(
+                params={"reader_study": reader_study.pk}
+            )
+        )
+
+        To then add, for example, a PDF report and a lung volume
+        value to the first archive item , provide the interface slugs together
+        with the respective value or file path as follows:
+        client.update_display_set(
+            display_set_pk=items[0].id,
+            values={
+                "report": [...],
+                "lung-volume": 1.9,
+            },
+        )
+        If you provide a value or file for an existing interface of the display
+        set, the old value will be overwritten by the new one, hence allowing you
+        to update existing display-set values.
+
+        Parameters
+        display_set_pk
+        values
+
+        Returns
+        -------
+        The updated display set
+        """
+        ds = yield from self.__org_api_meta.reader_studies.display_sets.detail(
+            pk=display_set_pk
+        )
+        return (
+            yield from self._update_socket_value_set(
+                target=ds,
+                description=values,
+                api=self.__org_api_meta.reader_studies.display_sets,
+            )
+        )
+
     def add_cases_to_reader_study(
         self,
         *,

--- a/gcapi/client.py
+++ b/gcapi/client.py
@@ -735,7 +735,7 @@ class ClientBase(ApiDefinitions, ClientInterface):
         This function updates an existing display set with the provided values
         and returns the updated display set.
 
-        You can use this function, for example, to add metadata to an display set.
+        You can use this function, for example, to add metadata to a display set.
 
         First, retrieve the display_set from your archive:
 

--- a/gcapi/client.py
+++ b/gcapi/client.py
@@ -747,7 +747,7 @@ class ClientBase(ApiDefinitions, ClientInterface):
         )
 
         To then add, for example, a PDF report and a lung volume
-        value to the first archive item , provide the interface slugs together
+        value to the first display set , provide the interface slugs together
         with the respective value or file path as follows:
         client.update_display_set(
             display_set_pk=items[0].id,

--- a/gcapi/exceptions.py
+++ b/gcapi/exceptions.py
@@ -6,5 +6,13 @@ class ObjectNotFound(GCAPIError):  # noqa: N818
     """Zero objects found when one was expected"""
 
 
+class SocketNotFound(ObjectNotFound):  # noqa: N818
+    """A socket could not be found when one was expected"""
+
+    def __init__(self, *args, slug, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.slug = slug
+
+
 class MultipleObjectsReturned(GCAPIError):  # noqa: N818
     """Multiple objects returned when one was expected"""

--- a/gcapi/gcapi.py
+++ b/gcapi/gcapi.py
@@ -143,6 +143,9 @@ class Client(httpx.Client, WrapApiInterfaces, ClientBase):
             *args, **kwargs
         )
 
+    def update_display_set(self, *args, **kwargs):
+        return self._wrap_function(super().update_display_set)(*args, **kwargs)
+
 
 class AsyncClient(httpx.AsyncClient, WrapApiInterfaces, ClientBase):
     def _wrap_generator(self, f):
@@ -201,5 +204,10 @@ class AsyncClient(httpx.AsyncClient, WrapApiInterfaces, ClientBase):
 
     async def add_cases_to_reader_study(self, *args, **kwargs):
         return await self._wrap_function(super().add_cases_to_reader_study)(
+            *args, **kwargs
+        )
+
+    async def update_display_set(self, *args, **kwargs):
+        return await self._wrap_function(super().update_display_set)(
             *args, **kwargs
         )

--- a/tests/async_integration_tests.py
+++ b/tests/async_integration_tests.py
@@ -762,63 +762,27 @@ async def test_add_cases_to_reader_study_invalid_interface(
 
 
 @pytest.mark.anyio
-async def test_add_cases_to_reader_study_invalid_path(
-    local_grand_challenge,
-):
-    file_path = Path(__file__).parent / "testdata" / "image10x10x1011.mha"
-    display_sets = [{"generic-medical-image": [file_path]}]
+async def test_add_cases_to_archive_invalid_interface(local_grand_challenge):
 
-    async with AsyncClient(
-        base_url=local_grand_challenge, verify=False, token=READERSTUDY_TOKEN
-    ) as c:
-        with pytest.raises(ValueError) as e:
-            await c.add_cases_to_reader_study(
-                reader_study="reader-study", display_sets=display_sets
-            )
-
-        assert str(e.value) == (
-            "Invalid file paths: "
-            f"{{'generic-medical-image': ['{file_path}']}}"
-        )
-
-
-@pytest.mark.anyio
-async def test_add_cases_to_reader_study_invalid_value(
-    local_grand_challenge,
-):
-    display_sets = [{"generic-medical-image": "not a list"}]
-
-    async with AsyncClient(
-        base_url=local_grand_challenge, verify=False, token=READERSTUDY_TOKEN
-    ) as c:
-        with pytest.raises(ValueError) as e:
-            await c.add_cases_to_reader_study(
-                reader_study="reader-study", display_sets=display_sets
-            )
-
-        assert str(e.value) == (
-            "Values for generic-medical-image (image) should be a list of file paths."
-        )
-
-
-@pytest.mark.anyio
-async def test_add_cases_to_reader_study_multiple_files(local_grand_challenge):
-    files = [
-        Path(__file__).parent / "testdata" / f
-        for f in ["test.csv", "test.csv"]
+    archive_items = [
+        {
+            "very-specific-medical-image": [
+                Path(__file__).parent / "testdata" / "image10x10x101.mha"
+            ]
+        },
     ]
 
-    display_sets = [{"predictions-csv-file": files}]
-
     async with AsyncClient(
-        base_url=local_grand_challenge, verify=False, token=READERSTUDY_TOKEN
+        base_url=local_grand_challenge, verify=False, token=ARCHIVE_TOKEN
     ) as c:
+
         with pytest.raises(ValueError) as e:
-            await c.add_cases_to_reader_study(
-                reader_study="reader-study", display_sets=display_sets
+            await c.add_cases_to_archive(
+                archive="archive", archive_items=archive_items
             )
 
         assert str(e.value) == (
-            "You can only upload one single file to interface "
-            "predictions-csv-file (file)."
+            "very-specific-medical-image is not an existing interface. "
+            "Please provide one from this list: "
+            "https://grand-challenge.org/components/interfaces/inputs/"
         )

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -517,6 +517,88 @@ def test_add_and_update_file_to_archive_item(local_grand_challenge):
     assert "test2.csv" in new_csv_socket_value.file
 
 
+def test_add_and_update_file_to_display_set(local_grand_challenge):
+    c = Client(
+        base_url=local_grand_challenge, verify=False, token=READERSTUDY_TOKEN
+    )
+
+    # Create a new display set in the reader study
+    display_set_pks = c.add_cases_to_reader_study(
+        reader_study="reader-study",
+        display_sets=[
+            {"generic-medical-image": TESTDATA / "image10x10x101.mha"},
+        ],
+    )
+
+    @recurse_call
+    def get_target_display_set():
+        # Wait for the image to be added (async task)
+        display_set = c.reader_studies.display_sets.detail(
+            pk=display_set_pks[0]
+        )
+        if len(display_set.values) != 1:
+            raise ValueError
+        return display_set
+
+    target_display_set = get_target_display_set()
+
+    # Update the display set with a CSV file
+    _ = c.update_display_set(
+        display_set_pk=target_display_set.pk,
+        values={
+            "predictions-csv-file": [TESTDATA / "test.csv"],
+        },
+    )
+
+    @recurse_call
+    def get_updated_display_set():
+        display_set = c.reader_studies.display_sets.detail(
+            target_display_set.pk
+        )
+        if len(display_set.values) != 2:
+            raise ValueError
+        return display_set
+
+    item_updated = get_updated_display_set()
+
+    csv_socket_value = next(
+        v
+        for v in item_updated.values
+        if v.interface.slug == "predictions-csv-file"
+    )
+    assert "test.csv" in csv_socket_value.file
+
+    updated_socket_value_count = len(item_updated.values)
+
+    # Update again, replacing the previous CSV with a new one
+    c.update_display_set(
+        display_set_pk=target_display_set.pk,
+        values={
+            "predictions-csv-file": [TESTDATA / "test2.csv"],
+        },
+    )
+
+    @recurse_call
+    def get_updated_again_display_set():
+        display_set = c.reader_studies.display_sets.detail(
+            target_display_set.pk
+        )
+        if csv_socket_value.pk in [v.pk for v in display_set.values]:
+            raise ValueError
+        return display_set
+
+    item_updated_again = get_updated_again_display_set()
+
+    assert len(item_updated_again.values) == updated_socket_value_count
+    new_csv_socket_value = next(
+        v
+        for v in item_updated_again.values
+        if v.interface.slug == "predictions-csv-file"
+    )
+    assert new_csv_socket_value.interface.slug == "predictions-csv-file"
+    assert "test2.csv" in new_csv_socket_value.file
+
+
 def test_add_and_update_value_to_archive_item(local_grand_challenge):
     c = Client(
         base_url=local_grand_challenge, verify=False, token=ARCHIVE_TOKEN
@@ -552,6 +634,45 @@ def test_add_and_update_value_to_archive_item(local_grand_challenge):
     updated_archive_item = c.archive_items.detail(pk=archive_item_pks[0])
     assert updated_archive_item.values[0].interface.slug == "metrics-json-file"
     assert updated_archive_item.values[0].value["foo2"] == "bar2"
+
+
+def test_add_and_update_value_to_display_set(local_grand_challenge):
+    c = Client(
+        base_url=local_grand_challenge, verify=False, token=READERSTUDY_TOKEN
+    )
+
+    # Create new display set with a structured value
+    display_set_pks = c.add_cases_to_reader_study(
+        reader_study="reader-study",
+        display_sets=[
+            {
+                "metrics-json-file": {"foo": "bar"},
+            },
+        ],
+    )
+
+    display_set = c.reader_studies.display_sets.detail(pk=display_set_pks[0])
+
+    assert display_set.values[0].interface.slug == "metrics-json-file"
+    assert display_set.values[0].value["foo"] == "bar"
+
+    # Update the structured value
+    display_set = c.update_display_set(
+        display_set_pk=display_set.pk,
+        values={
+            "metrics-json-file": {"foo2": "bar2"},
+        },
+    )
+
+    assert (
+        display_set.values[0].value["foo2"] == "bar2"
+    ), "Sanity, values are applied directly"
+
+    updated_display_set = c.reader_studies.display_sets.detail(
+        pk=display_set_pks[0]
+    )
+    assert updated_display_set.values[0].interface.slug == "metrics-json-file"
+    assert updated_display_set.values[0].value["foo2"] == "bar2"
 
 
 @pytest.mark.parametrize(

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -718,65 +718,24 @@ def test_add_cases_to_reader_study_invalid_interface(local_grand_challenge):
     )
 
 
-def test_add_cases_to_reader_study_invalid_path(local_grand_challenge):
+def test_add_cases_to_archive_invalid_interface(local_grand_challenge):
     c = Client(
-        base_url=local_grand_challenge, verify=False, token=READERSTUDY_TOKEN
+        base_url=local_grand_challenge, verify=False, token=ARCHIVE_TOKEN
     )
 
-    file_path = Path(__file__).parent / "testdata" / "image10x10x1011.mha"
-    display_sets = [
-        {"generic-medical-image": [file_path]},
+    archive_items = [
+        {
+            "very-specific-medical-image": [
+                Path(__file__).parent / "testdata" / "image10x10x101.mha"
+            ]
+        },
     ]
 
     with pytest.raises(ValueError) as e:
-        c.add_cases_to_reader_study(
-            reader_study="reader-study", display_sets=display_sets
-        )
+        c.add_cases_to_archive(archive="archive", archive_items=archive_items)
 
     assert str(e.value) == (
-        "Invalid file paths: " f"{{'generic-medical-image': ['{file_path}']}}"
-    )
-
-
-def test_add_cases_to_reader_study_invalid_value(local_grand_challenge):
-    c = Client(
-        base_url=local_grand_challenge, verify=False, token=READERSTUDY_TOKEN
-    )
-
-    display_sets = [
-        {"generic-medical-image": "not a list"},
-    ]
-
-    with pytest.raises(ValueError) as e:
-        c.add_cases_to_reader_study(
-            reader_study="reader-study", display_sets=display_sets
-        )
-
-    assert str(e.value) == (
-        "Values for generic-medical-image (image) should be a list of file paths."
-    )
-
-
-def test_add_cases_to_reader_study_multiple_files(local_grand_challenge):
-    c = Client(
-        base_url=local_grand_challenge, verify=False, token=READERSTUDY_TOKEN
-    )
-
-    files = [
-        Path(__file__).parent / "testdata" / f
-        for f in ["test.csv", "test.csv"]
-    ]
-
-    display_sets = [
-        {"predictions-csv-file": files},
-    ]
-
-    with pytest.raises(ValueError) as e:
-        c.add_cases_to_reader_study(
-            reader_study="reader-study", display_sets=display_sets
-        )
-
-    assert str(e.value) == (
-        "You can only upload one single file to interface "
-        "predictions-csv-file (file)."
+        "very-specific-medical-image is not an existing interface. "
+        "Please provide one from this list: "
+        "https://grand-challenge.org/components/interfaces/inputs/"
     )


### PR DESCRIPTION
Part of pitch:
- https://github.com/DIAGNijmegen/rse-roadmap/issues/406

This PR will update the existing helper function `add_cases_to_reader_study` and add a new helper function `update_display_set` (+ tests).

In addition, a deprecation warning will now fire when someone uses `upload_cases`. Imho that function should go since it does upload for answers/archives/archive_item/reader_sets. However, only for images. Which is very confusing. Far better to use the resilient strategies for that via the other helper functions. 

Also: some renaming of "interface" => "socket".