### PR TITLE
Add Syncronous Wrapper for Async Client

### DIFF
--- a/gcapi/sync_support.py
+++ b/gcapi/sync_support.py
@@ -1,0 +1,128 @@
+import asyncio
+import inspect
+import threading
+
+from gcapi.apibase import APIBase
+
+
+def is_async_callable(obj):
+    """Checks for async methods but also hits async __call__ methods"""
+    if inspect.iscoroutinefunction(obj):
+        return True
+    else:
+        try:
+            call_method = obj.__call__
+        except AttributeError:
+            return False
+        else:
+            return inspect.iscoroutinefunction(call_method)
+
+
+def assert_not_in_running_loop():
+    """
+    When in a running asynchronous context, we present an informative error message.
+    """
+    try:
+        event_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        pass
+    else:
+        if event_loop.is_running():
+            raise RuntimeError(
+                "Cannot use the synchronous client while an event loop is running. "
+                "Please use the asynchronous client in an asynchronous context."
+            )
+
+
+class SyncCompatWrapper:
+    """
+    A wrapper for an asynchronous instance that allows synchronous access
+    to its methods.
+
+    Does not work in an already running event loop context. Sorry!
+
+    Usage:
+    ```python
+        async_instance = AsyncClient()
+        sync_instance = SyncCompatWrapper(async_instance=async_instance)
+
+        sync_result = sync_instance.some_async_method()
+    ```
+    """
+
+    def __init__(self, *, async_instance, lock=None):
+        assert_not_in_running_loop()
+
+        self.__async_instance = async_instance
+        self.__wrapping_lock = lock or threading.Lock()
+
+    def __wrap_async_callable(self, /, func):
+        def wrapper(*args, **kwargs):
+            with self.__wrapping_lock:
+                coro = func(*args, **kwargs)
+                return asyncio.run(coro)
+
+        return wrapper
+
+    def __wrap_async_gen_function(self, /, func):
+        def wrapper(*args, **kwargs):
+            aiter = func(*args, **kwargs)
+            while True:
+                try:
+                    sync_func = self.__wrap_async_callable(aiter.__anext__)
+                    yield sync_func()
+                except StopAsyncIteration:
+                    self.__wrap_async_callable(aiter.aclose)()
+                    break
+
+        return wrapper
+
+    def __getattr__(self, name):
+        attr = getattr(self.__async_instance, name)
+
+        if self.__wrapping_lock.locked():
+            # We're in an intentionally asynchronous context,
+            # so we return the attribute
+            return attr
+        elif isinstance(attr, APIBase):
+            return SyncCompatWrapper(
+                async_instance=attr, lock=self.__wrapping_lock
+            )
+        elif is_async_callable(attr):
+            return self.__wrap_async_callable(attr)
+        elif inspect.isasyncgenfunction(attr):
+            return self.__wrap_async_gen_function(attr)
+        elif isinstance(attr, APIBase):
+            return SyncCompatWrapper(
+                async_instance=attr, lock=self.__wrapping_lock
+            )
+        else:
+            return attr
+
+    def __call__(self, *args, **kwargs):
+        if is_async_callable(self.__async_instance):
+            sync_func = self.__wrap_async_callable(self.__async_instance)
+        else:
+            sync_func = self.__async_instance
+
+        return sync_func(*args, **kwargs)
+
+
+class SyncCompatWrapperMeta(type):
+    """
+    A metaclass that wraps the instance of a class in a `SyncCompatWrapper`
+
+    Usage:
+    ```python
+        class MySyncClass(MyAsyncClass, metaclass=SyncCompatWrapperMeta):
+            async def some_async_method(self):
+                return await self._some_internal_async_method()
+
+        my_sync_instance = MySyncClass()
+        sync_result = my_sync_instance.some_async_method()
+    ```
+    """
+
+    def __call__(cls, *args, **kwargs):
+        instance = super().__call__(*args, **kwargs)
+        return SyncCompatWrapper(async_instance=instance)

--- a/tests/test_sync_support.py
+++ b/tests/test_sync_support.py
@@ -1,0 +1,120 @@
+import asyncio
+
+import pytest
+
+from gcapi.apibase import APIBase
+from gcapi.sync_support import SyncCompatWrapperMeta
+
+
+class SubAPI(APIBase):
+    def __init__(self, parent):
+        self.parent = parent
+
+    async def func(self):
+        await asyncio.sleep(1e-6)
+        return 42
+
+    async def func_calling_parent_api(self):
+        return await self.parent()
+
+    def __call__(self):
+        return 42
+
+
+class API(APIBase):
+    async def func(self):
+        await asyncio.sleep(1e-6)
+        return 42
+
+    async def func_calling_client(self):
+        return await self.parent()
+
+    async def func_calling_parent_func(self):
+        return await self.parent.func_b()
+
+    def __init__(self, parent):
+        self.parent = parent
+        self.sub_api = SubAPI(parent=parent)
+
+    async def __call__(self):
+        await asyncio.sleep(1e-6)
+        return 42
+
+
+class AsyncClient:
+    def __init__(self):
+        self.api = API(self)
+
+    def func(self):
+        return 42
+
+    async def async_func(self) -> int:
+        await asyncio.sleep(1e-6)
+        return 42
+
+    async def async_to_async_func(self):
+        return await self.async_func()
+
+    async def __call__(self):
+        await asyncio.sleep(1e-6)
+        return 42
+
+    def sync_gen_func(self):
+        yield from [42] * 3
+
+    async def async_gen_func(self):
+        for i in [42] * 3:
+            await asyncio.sleep(1e-6)
+            yield i
+
+
+def test_sync_compat_calls():
+    class SyncClient(AsyncClient, metaclass=SyncCompatWrapperMeta):
+        pass
+
+    client = SyncClient()
+
+    # Regular calls
+    assert client.func() == 42
+    assert client.async_func() == 42
+    assert client.async_to_async_func() == 42
+    assert client() == 42
+
+    # Test API methods
+    assert client.api.func() == 42
+    assert client.api.sub_api.func() == 42
+    assert client.api.func_calling_client() == 42
+    assert client.api.sub_api.func_calling_parent_api() == 42
+
+    # Test api calls
+    assert client.api() == 42  # Call async __call__ method
+    assert client.api.sub_api() == 42  # Call sync __call__ method
+    assert client.api.parent() == 42  # Call 'up' async __call__ method
+
+    # Test generator methods
+    assert list(client.sync_gen_func()) == [42, 42, 42]
+    assert list(client.async_gen_func()) == [42, 42, 42]
+
+    # Call another async while iterating an async_gen_func
+    # Should work since the two methods spawn independent loops
+    # that never run at the same time.
+    all_results = []
+    for i in client.async_gen_func():
+        all_results.append(i)
+        assert i == 42
+        assert client.async_func() == 42
+    assert all_results == [42, 42, 42]  # Sanity that we still got all results
+
+
+@pytest.mark.anyio
+async def test_sync_compat_in_existing_event_loop():
+    class SyncClient(AsyncClient, metaclass=SyncCompatWrapperMeta):
+        pass
+
+    context = pytest.raises(
+        RuntimeError,
+        match="Cannot use the synchronous client while an event loop is running",
+    )
+
+    with context:
+        SyncClient()


### PR DESCRIPTION
Nice-to-have of pitch:
- https://github.com/DIAGNijmegen/rse-roadmap/issues/406

This adds the wrapper that is not hooked into anything: just adds the wrapper what would allow us to define the client in pure async 'colours'.

What is purposefully left not-implemented is using a wrapped asynchronous client in a asynchronous context: developers should just use the asynchronous client instead.

Maybe a ToDo down the road: try to correct static typing of the wrapped client. For now, at least, MyPy does not complain.

It has some tests that cover (I think) all the ways the `AsyncClient` can be used. 
I opted to use the very basic runtime `asyncio.run` over the static wrapper `asgrif.sync.async_to_sync`. The latter breaks down for two reasons:
- By default adding the `async_to_sync` statically does not handle cross-calling of wrapped methods
- When using `async_to_sync` dynamically it is faced with async generators correctly (e.g. `iterate_all`) it only yields once and then shuts down the generator