### PR TITLE
Remove email address

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 authors = [
-    {name = "James Meakin", email = "support@grand-challenge.org" },
+    {name = "James Meakin"},
 ]
 license = {text = "Apache-2.0"}
 requires-python = ">=3.9, <4.0"


### PR DESCRIPTION
Spammers scrape Github and PyPi. Emails are not required, there is a link to the repository if people need to get in touch.