### PR TITLE
Add algorithm images API

### DIFF
--- a/gcapi/client.py
+++ b/gcapi/client.py
@@ -191,6 +191,11 @@ class AlgorithmJobsAPI(ModifiableMixin, APIBase[gcapi.models.HyperlinkedJob]):
         yield from self.iterate_all(params={"image": pk})
 
 
+class AlgorithmImagesAPI(APIBase[gcapi.models.AlgorithmImage]):
+    base_path = "algorithms/images/"
+    model = gcapi.models.AlgorithmImage
+
+
 class ArchivesAPI(APIBase[gcapi.models.Archive]):
     base_path = "archives/"
     model = gcapi.models.Archive
@@ -363,6 +368,7 @@ class ApiDefinitions:
     uploads: UploadsAPI
     algorithms: AlgorithmsAPI
     algorithm_jobs: AlgorithmJobsAPI
+    algorithm_images: AlgorithmImagesAPI
     archives: ArchivesAPI
     workstation_configs: WorkstationConfigsAPI
     raw_image_upload_sessions: UploadSessionsAPI

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -105,6 +105,20 @@ def test_get_display_sets(local_grand_challenge):
     assert isinstance(display_sets[0], gcapi.models.DisplaySet)
 
 
+def test_get_algorithm_images(local_grand_challenge):
+    c = Client(
+        base_url=local_grand_challenge,
+        verify=False,
+        token=DEMO_PARTICIPANT_TOKEN,
+    )
+    algorithm = c.algorithms.detail(slug="test-algorithm-evaluation-image-0")
+    algorithm_images = list(
+        c.algorithm_images.iterate_all(params={"algorithm": algorithm.pk})
+    )
+    assert len(algorithm_images) > 0
+    assert isinstance(algorithm_images[0], gcapi.models.AlgorithmImage)
+
+
 def test_get_answers(local_grand_challenge):
     c = Client(
         base_url=local_grand_challenge, verify=False, token=READERSTUDY_TOKEN


### PR DESCRIPTION
Was missing.  Submitted jobs report back a  hyperlinked `algorithm_image`. This allows one to convert that `api_url` to some more details.