### PR TITLE
[Typing] Increase strictness MyPy : refactor strategies

### DIFF
--- a/gcapi/apibase.py
+++ b/gcapi/apibase.py
@@ -159,7 +159,7 @@ class ModifiableMixin(Common):
         elif isinstance(data, dict):
             return {k: self.recurse_model_dump(v) for k, v in data.items()}
         elif is_pydantic_dataclass(type(data)):
-            return RootModel[type(data)](data).model_dump()
+            return RootModel[type(data)](data).model_dump()  # type: ignore
         else:
             return data
 

--- a/gcapi/apibase.py
+++ b/gcapi/apibase.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 import collections
 from collections.abc import Iterator, Sequence
-from typing import Any, Generic, TypeVar, overload
+from typing import TYPE_CHECKING, Generic, TypeVar, overload
 from urllib.parse import urljoin
 
-from httpx import URL, HTTPStatusError
-from httpx._types import URLTypes
+from httpx import HTTPStatusError
 from pydantic import RootModel
 from pydantic.dataclasses import is_pydantic_dataclass
 
@@ -12,29 +13,8 @@ from gcapi.exceptions import MultipleObjectsReturned, ObjectNotFound
 
 T = TypeVar("T")
 
-
-class ClientInterface:
-    @property
-    def base_url(self) -> URL: ...
-
-    @base_url.setter
-    def base_url(self, v: URLTypes): ...
-
-    def validate_url(self, url): ...
-
-    def __call__(
-        self,
-        method="GET",
-        url="",
-        path="",
-        params=None,
-        json=None,
-        extra_headers=None,
-        files=None,
-        data=None,
-        follow_redirects=False,
-    ) -> Any:
-        raise NotImplementedError
+if TYPE_CHECKING:
+    from gcapi import Client
 
 
 class PageResult(Generic[T], collections.abc.Sequence):
@@ -80,14 +60,14 @@ class PageResult(Generic[T], collections.abc.Sequence):
 
 class Common(Generic[T]):
     model: type[T]
-    _client: ClientInterface
+    _client: Client
     base_path: str
 
 
 class APIBase(Generic[T], Common[T]):
-    sub_apis: dict[str, type["APIBase"]] = {}
+    sub_apis: dict[str, type[APIBase]] = {}
 
-    def __init__(self, client) -> None:
+    def __init__(self, client: Client) -> None:
         if isinstance(self, ModifiableMixin):
             ModifiableMixin.__init__(self)
 

--- a/gcapi/typing.py
+++ b/gcapi/typing.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Union
+from typing import Any, Union
 
 import gcapi.models
 
@@ -11,14 +11,7 @@ FileSource = Union[
 ]
 
 
-SocketValueSetDescription = dict[
-    Union[str, gcapi.models.ComponentInterface],
-    Union[
-        FileSource,
-        gcapi.models.HyperlinkedComponentInterfaceValue,
-        gcapi.models.HyperlinkedImage,
-    ],
-]
+SocketValueSetDescription = dict[str, Any]
 
 SocketValueSet = Union[
     gcapi.models.DisplaySet,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,15 @@ python_files = "tests.py test_*.py *_tests.py"
 addopts = "--strict-markers --showlocals"
 xfail_strict = true
 
+[tool.mypy]
+python_version = 3.9
+plugins = "pydantic.mypy"
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+strict_equality = true
+check_untyped_defs = true
+
 [tool.tox]
 legacy_tox_ini = """
 [tox]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,9 @@
 [mypy]
 python_version = 3.9
 plugins = pydantic.mypy
+warn_unused_configs = True
+warn_redundant_casts = True
+warn_unused_ignores = True
 
 [flake8]
 max-line-length = 79

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,7 @@ warn_unused_configs = True
 warn_redundant_casts = True
 warn_unused_ignores = True
 strict_equality = True
+check_untyped_defs = True
 
 [flake8]
 max-line-length = 79

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,3 @@
-[mypy]
-python_version = 3.9
-plugins = pydantic.mypy
-warn_unused_configs = True
-warn_redundant_casts = True
-warn_unused_ignores = True
-strict_equality = True
-check_untyped_defs = True
-
 [flake8]
 max-line-length = 79
 docstring-convention = numpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ plugins = pydantic.mypy
 warn_unused_configs = True
 warn_redundant_casts = True
 warn_unused_ignores = True
+strict_equality = True
 
 [flake8]
 max-line-length = 79

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -1,6 +1,7 @@
 from functools import partial
 from io import BytesIO
 from pathlib import Path
+from typing import cast
 
 import pytest
 from httpx import HTTPStatusError
@@ -647,7 +648,8 @@ def test_add_and_update_value_to_archive_item(local_grand_challenge):
     archive_item = c.archive_items.detail(pk=archive_item_pks[0])
 
     assert archive_item.values[0].interface.slug == "metrics-json-file"
-    assert archive_item.values[0].value["foo"] == "bar"
+    value = cast(dict, archive_item.values[0].value)
+    assert value["foo"] == "bar"
 
     # Update value
     archive_item = c.update_archive_item(
@@ -657,13 +659,13 @@ def test_add_and_update_value_to_archive_item(local_grand_challenge):
         },
     )
 
-    assert (
-        archive_item.values[0].value["foo2"] == "bar2"
-    ), "Sanity, values are applied directly"
+    value = cast(dict, archive_item.values[0].value)
+    assert value["foo2"] == "bar2", "Sanity, values are applied directly"
 
     updated_archive_item = c.archive_items.detail(pk=archive_item_pks[0])
     assert updated_archive_item.values[0].interface.slug == "metrics-json-file"
-    assert updated_archive_item.values[0].value["foo2"] == "bar2"
+    value = cast(dict, archive_item.values[0].value)
+    assert value["foo2"] == "bar2"
 
 
 def test_add_and_update_value_to_display_set(local_grand_challenge):
@@ -684,7 +686,7 @@ def test_add_and_update_value_to_display_set(local_grand_challenge):
     display_set = c.reader_studies.display_sets.detail(pk=display_set_pks[0])
 
     assert display_set.values[0].interface.slug == "metrics-json-file"
-    assert display_set.values[0].value["foo"] == "bar"
+    assert cast(dict, display_set.values[0].value)["foo"] == "bar"
 
     # Update the structured value
     display_set = c.update_display_set(
@@ -695,14 +697,14 @@ def test_add_and_update_value_to_display_set(local_grand_challenge):
     )
 
     assert (
-        display_set.values[0].value["foo2"] == "bar2"
+        cast(dict, display_set.values[0].value)["foo2"] == "bar2"
     ), "Sanity, values are applied directly"
 
     updated_display_set = c.reader_studies.display_sets.detail(
         pk=display_set_pks[0]
     )
     assert updated_display_set.values[0].interface.slug == "metrics-json-file"
-    assert updated_display_set.values[0].value["foo2"] == "bar2"
+    assert cast(dict, display_set.values[0].value)["foo2"] == "bar2"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_create_strategies.py
+++ b/tests/test_create_strategies.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+import gcapi.create_strategies
 from gcapi.create_strategies import (
     FileCreateStrategy,
     FileFromSVCreateStrategy,
@@ -17,6 +18,7 @@ from gcapi.create_strategies import (
     ValueCreateStrategy,
     ValueFromFileCreateStrategy,
     ValueFromSVStrategy,
+    _strategy_registry,
     clean_file_source,
     select_socket_value_strategy,
 )
@@ -410,3 +412,21 @@ def test_job_inputs_create_prep(algorithm, inputs, context):
             inputs=inputs,
             client=MagicMock(),
         )
+
+
+def test_ordering_strategy_registry():
+    """Ensure that the strategy registry is ordered correctly."""
+
+    assert _strategy_registry == [
+        # File
+        gcapi.create_strategies.FileCreateStrategy,
+        gcapi.create_strategies.FileJSONCreateStrategy,
+        gcapi.create_strategies.FileFromSVCreateStrategy,
+        # Image
+        gcapi.create_strategies.ImageCreateStrategy,
+        gcapi.create_strategies.ImageFromSVCreateStrategy,
+        # Value
+        gcapi.create_strategies.ValueFromFileCreateStrategy,
+        gcapi.create_strategies.ValueFromSVStrategy,
+        gcapi.create_strategies.ValueCreateStrategy,
+    ]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,10 +1,10 @@
-# type: ignore
+from typing import Any
 
 import pytest
 
 from gcapi.models import Algorithm
 
-DEFAULT_ALGORITHM_ARGS = {
+DEFAULT_ALGORITHM_ARGS: dict[str, Any] = {
     "pk": "1234",
     "api_url": "",
     "url": "",
@@ -19,12 +19,12 @@ DEFAULT_ALGORITHM_ARGS = {
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_extra_definitions_allowed():
-    a = Algorithm(**DEFAULT_ALGORITHM_ARGS, extra="extra")
+    a = Algorithm(**DEFAULT_ALGORITHM_ARGS, extra="extra")  # type: ignore
 
     assert a.pk == "1234"
 
     with pytest.raises(AttributeError):
-        a.extra
+        a.extra  # type: ignore
 
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,3 +1,5 @@
+# type: ignore
+
 import pytest
 
 from gcapi.models import Algorithm

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -27,7 +27,7 @@ class EndlessRetries(BaseRetryStrategy):
 
 def test_invalid_retries():
     with pytest.raises(RuntimeError):
-        RetryTransport(retry_strategy=object)
+        RetryTransport(retry_strategy=object)  # type: ignore
 
 
 def test_null_retries():


### PR DESCRIPTION
Part of:
 - #166 

This PR adds the following strictness to the mypy config:
```
warn_unused_configs = True
warn_redundant_casts = True
warn_unused_ignores = True
strict_equality = True
check_untyped_defs = True
```

This has led me to delete the `ClientInterface` (just use the `Client` directly since we don't have Async vs Sync anymore).

The create strategies for socket values were sort of spagetti already but with typing it became totally tangled and unreadable. As such I bit the bullet and refactor them in a fall-through pattern: each strategy is tried in turn and the first one without a specific error (`NotSupported`) gets used.

Since the `prepare()` was a construct to facilite the hybrid constructs (`yield from`) I've opted to move those checks to the `__init__` of each strategy: makes way more sense imho.

`UserUploads` are now no longer flagged with their archive_item / display_set parent. Instead the user_upload is set in the POST that updates the archive_item/ display_set: far simpler.
