### PR TITLE
Update python version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/DIAGNijmegen/rse-gcapi/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/DIAGNijmegen/rse-gcapi/actions/workflows/ci.yml?query=branch%3Amain)
 [![PyPI](https://img.shields.io/pypi/v/gcapi)](https://pypi.org/project/gcapi/)
-[![PyPI - Python Version](https://img.shields.io/badge/dynamic/json?query=info.requires_python&label=python&url=https%3A%2F%2Fpypi.org%2Fpypi%2Fgcapi%2Fjson)](https://pypi.org/project/gcapi/)
+![Python Version from PEP 621 TOML](https://img.shields.io/python/required-version-toml?tomlFilePath=https%3A%2F%2Fraw.githubusercontent.com%2FDIAGNijmegen%2Frse-gcapi%2Frefs%2Fheads%2Fmain%2Fpyproject.toml)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 Python client for the grand-challenge.org REST API


### PR DESCRIPTION
## Current

<img width="439" height="60" alt="afbeelding" src="https://github.com/user-attachments/assets/c99c114e-30e7-4240-a2fa-b31b183e0214" />


## New
<img width="439" height="60" alt="afbeelding" src="https://github.com/user-attachments/assets/217ba136-47d6-4ca1-8e03-b805c2d385e0" />


See discussion here: https://github.com/badges/shields/issues/5551#issuecomment-755503136 and finally an implementation here: https://shields.io/badges/python-version-from-pep-621-toml