### PR TITLE
Correct mkdocs command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,4 +105,4 @@ jobs:
           python-version: ${{ env.MINIMUM_PYTHON_VERSION }}
       - name:
         run: |
-          uv run mkdocs gh-pages --force
+          uv run mkdocs gh-deploy --force


### PR DESCRIPTION
Small mistake in the command that pushes the mkdocs docs.

Already fixed it ad hoc via a manual release.