### PR TITLE
fix(models): accept null exec_duration/invoke_duration on Job and Evaluation models (#268)

### DIFF
--- a/gcapi/models.py
+++ b/gcapi/models.py
@@ -1543,8 +1543,8 @@ class HyperlinkedJob:
     hanging_protocol: HangingProtocol | None
     optional_hanging_protocols: list[HangingProtocol]
     view_content: Any
-    exec_duration: str
-    invoke_duration: str
+    exec_duration: str | None
+    invoke_duration: str | None
     algorithm: str
 
 
@@ -1750,8 +1750,8 @@ class Evaluation:
     rank_per_metric: Any | None
     status: str
     title: str
-    exec_duration: str
-    invoke_duration: str
+    exec_duration: str | None
+    invoke_duration: str | None
 
 
 @dataclass
@@ -1767,8 +1767,8 @@ class ExternalEvaluation:
     rank_per_metric: Any | None
     status: str
     title: str
-    exec_duration: str
-    invoke_duration: str
+    exec_duration: str | None
+    invoke_duration: str | None
     algorithm_model: dict[str, Any] | None
     algorithm_image: dict[str, Any]
     claimed_by: int | None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,67 @@
+"""Pydantic-validation regression tests for `gcapi.models`.
+
+The bug in #268 was that `HyperlinkedJob.exec_duration` / `invoke_duration`
+were typed `str`, so the upstream API returning `null` for not-yet-finished
+jobs raised `ValidationError` and listing jobs failed. These tests pin
+that the duration fields accept `None`.
+"""
+
+from pydantic import TypeAdapter
+
+from gcapi.models import (
+    Evaluation,
+    ExternalEvaluation,
+    HyperlinkedJob,
+)
+
+
+def _build_hyperlinked_job_payload(**overrides):
+    base = {
+        "pk": "00000000-0000-0000-0000-000000000000",
+        "url": "https://example.test/jobs/1/",
+        "api_url": "https://example.test/api/v1/jobs/1/",
+        "algorithm_image": "https://example.test/algos/1/",
+        "inputs": [],
+        "outputs": [],
+        "status": "Provisioned",
+        "hanging_protocol": None,
+        "optional_hanging_protocols": [],
+        "view_content": None,
+        "exec_duration": None,
+        "invoke_duration": None,
+        "algorithm": "https://example.test/algorithms/1/",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_hyperlinked_job_accepts_null_durations():
+    """Regression for #268: API returns null for in-flight jobs."""
+    HyperlinkedJob_TA = TypeAdapter(HyperlinkedJob)
+    job = HyperlinkedJob_TA.validate_python(_build_hyperlinked_job_payload())
+    assert job.exec_duration is None
+    assert job.invoke_duration is None
+
+
+def test_hyperlinked_job_still_accepts_str_durations():
+    """Finished jobs return ISO-8601 duration strings; still valid."""
+    HyperlinkedJob_TA = TypeAdapter(HyperlinkedJob)
+    payload = _build_hyperlinked_job_payload(
+        exec_duration="00:01:23.456",
+        invoke_duration="00:00:42.000",
+    )
+    job = HyperlinkedJob_TA.validate_python(payload)
+    assert job.exec_duration == "00:01:23.456"
+    assert job.invoke_duration == "00:00:42.000"
+
+
+def test_evaluation_models_accept_null_durations():
+    """Same fix applied to Evaluation / ExternalEvaluation; sanity-check
+    via TypeAdapter that they don't reject None on the duration fields."""
+    for cls in (Evaluation, ExternalEvaluation):
+        # We don't construct full payloads here — just confirm the field
+        # types declare Optional[str] so a future regression to bare `str`
+        # would also break this assertion.
+        anns = getattr(cls, "__annotations__", {})
+        assert "None" in str(anns["exec_duration"]) or anns["exec_duration"] is type(None) or "Optional" in str(anns["exec_duration"]) or "|" in str(anns["exec_duration"])
+        assert "None" in str(anns["invoke_duration"]) or anns["invoke_duration"] is type(None) or "Optional" in str(anns["invoke_duration"]) or "|" in str(anns["invoke_duration"])


### PR DESCRIPTION
## Summary

Fixes #268. Listing jobs raised:

```
ValidationError: 2 validation errors for HyperlinkedJob
exec_duration   Input should be a valid string [...] input_value=None
invoke_duration Input should be a valid string [...] input_value=None
```

The upstream API (rse-grand-challenge#4609) returns ``null`` for these fields on jobs that haven't finished yet, but ``HyperlinkedJob``, ``Evaluation``, and ``ExternalEvaluation`` all typed them as ``str`` — so any in-flight job in the response broke the entire list deserialization. The reporter (a project contributor) noted the server-side fix landed and asked for matching gcapi tests.

## Change

``gcapi/models.py`` — flip the three sites where ``exec_duration: str`` / ``invoke_duration: str`` appear to ``str | None``. Done via ``Edit replace_all`` so all three classes (``HyperlinkedJob``, ``Evaluation``, ``ExternalEvaluation``) get the same treatment in one swap.

## Test plan

- [x] Full suite: ``pytest tests/ --ignore=tests/integration_tests.py`` — 122 passed
- [x] New ``tests/test_models.py``:
  - ``test_hyperlinked_job_accepts_null_durations`` — fails on ``main`` (the bug), passes here
  - ``test_hyperlinked_job_still_accepts_str_durations`` — finished-job case still validates
  - ``test_evaluation_models_accept_null_durations`` — sanity check via annotation introspection that ``Evaluation`` / ``ExternalEvaluation`` got the same fix, so a future regression to bare ``str`` would also fail this test